### PR TITLE
Updating package.json to use the volta key rather than the deprecated toolchain key

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "fastboot-app-server": "^1.1.2-beta.1",
     "json-server": "^0.14.2"
   },
-  "toolchain": {
+  "volta": {
     "node": "12.1.0",
     "yarn": "1.15.2"
   }


### PR DESCRIPTION
Volta has explicitly deprecated the `toolchain` key within package.json to configure the tools/versions. The new key is `volta`. This PR converts to using that instead.