### PR TITLE
Update git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Particularly if you’ve never tried it before, you should install [Microsoft Vi
 ### Clone the Project
 
 ```sh
-git clone git@github.com:mike-north/ember-octane-workshop.git shlack
+git clone https://github.com/mike-north/ember-octane-workshop.git shlack
 ```
 
 ### Install dependencies


### PR DESCRIPTION
When running the set up steps I noticed that the original command `git clone git@github.com:mike-north/ember-octane-workshop.git shlack` would fail with the following error:
```
Cloning into 'shlack'...
The authenticity of host 'github.com (192.30.255.112)' can't be established.
RSA key fingerprint is SHA256:--REDACTED--.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```
The proposed command seems to work instead.
`git clone https://github.com/mike-north/ember-octane-workshop.git shlack`