### PR TITLE
updated starter html to resolve some a11y issues

### DIFF
--- a/starter-files/starter.html
+++ b/starter-files/starter.html
@@ -22,7 +22,7 @@
   <div class="team-selector__add-team-button cursor-pointer p-4">
     <div
       class="bg-white opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden">
-      <svg class="fill-current h-10 w-10 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <svg aria-hidden="true" class="fill-current h-10 w-10 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
         <path
           d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z">
         </path>
@@ -40,17 +40,17 @@
       </h1>
 
       <div class="team-sidebar__current-user-indicator flex items-center mb-6">
-        <svg class="h-2 w-2 fill-current text-green mr-2" viewBox="0 0 20 20">
+        <svg aria-hidden="true" class="h-2 w-2 fill-current text-green mr-2" viewBox="0 0 20 20">
           <circle cx="10" cy="10" r="10"></circle>
         </svg>
-        <span class="team-sidebar__current-user-name text-white opacity-50 text-sm">
+        <span class="team-sidebar__current-user-name text-white text-sm">
           Mike North
         </span>
       </div>
     </div>
 
     <div>
-      <svg class="h-6 w-6 fill-current text-white opacity-25" viewBox="0 0 20 20">
+      <svg aria-hidden="true" class="h-6 w-6 fill-current text-white opacity-25" viewBox="0 0 20 20">
         <path
           d="M14 8a4 4 0 1 0-8 0v7h8V8zM8.027 2.332A6.003 6.003 0 0 0 4 8v6l-3 2v1h18v-1l-3-2V8a6.003 6.003 0 0 0-4.027-5.668 2 2 0 1 0-3.945 0zM12 18a2 2 0 1 1-4 0h4z"
           fill-rule="evenodd"></path>
@@ -62,8 +62,8 @@
     <div class="px-4 mb-2 text-white flex justify-between items-center">
       <h2 class="opacity-75 text-lg">Channels</h2>
 
-      <button class="team-sidebar__join-channel-button text-white" aria-label="Join channel" role="button">
-        <svg class="fill-current h-4 w-4 opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <button class="team-sidebar__join-channel-button text-white" aria-label="Join channel">
+        <svg aria-hidden="true" class="fill-current h-4 w-4 opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
           <path
             d="M11 9h4v2h-4v4H9v-4H5V9h4V5h2v4zm-1 11a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16z">
           </path>
@@ -72,14 +72,14 @@
     </div>
 
     <a href="/li/general" data-channel-id="general"
-      class="team-sidebar__channel-link py-1 px-4 text-white no-underline block opacity-75 bg-teal-dark">
+      class="team-sidebar__channel-link py-1 px-4 text-black no-underline block bg-teal">
       <span aria-hidden="true">#</span>
       general
     </a>
   </nav>
 
   <footer class="mx-4 mb-2 text-white">
-    <button class="text-white rounded bg-grey-dark hover:bg-red-darker p-2 team-sidebar__logout-button">
+    <button class="text-white rounded bg-grey-darker hover:bg-red-darker p-2 team-sidebar__logout-button">
       Logout
     </button>
   </footer>
@@ -96,19 +96,19 @@
         general
       </h3>
 
-      <h4 class="text-grey-dark text-sm truncate channel-header__description">
+      <h4 class="text-grey-darker text-sm truncate channel-header__description">
         Just some general people generally chatting about general things
       </h4>
     </div>
 
-    <form
+    <form role="search" 
       class="ml-auto md:block border border-grey rounded-lg pl-3 pr-2 py-1 flex flex-row-reverse items-center search-form">
       <label for="search" class="sr-only">Search messages</label>
 
       <input placeholder="Search" class="appearance-none search-form__field" id="search" type="search">
 
-      <button aria-label="Submit search" class="search-form__button">
-        <svg class="fill-current text-grey h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <button aria-label="Submit search" type="submit" class="search-form__button">
+        <svg aria-hidden="true" class="fill-current text-grey h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
           <path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z">
           </path>
         </svg>
@@ -145,7 +145,7 @@
       <button
         class="message__delete-button border-transparent hover:border-red-light show-on-hover hover:bg-red-lightest border-1 rounded mb-1 pl-3 pr-2 py-1"
         aria-label="delete message">
-        🗑
+        <span role="presentation" aria-hidden="true">🗑</span>
       </button>
     </div>
 
@@ -176,7 +176,7 @@
       <button
         class="message__delete-button border-transparent hover:border-red-light show-on-hover hover:bg-red-lightest border-1 rounded mb-1 pl-3 pr-2 py-1"
         aria-label="delete message">
-        🗑
+        <span role="presentation" aria-hidden="true">🗑</span>
       </button>
     </div>
 
@@ -185,12 +185,12 @@
   <!-- Channel Footer -->
   <footer class="pb-6 px-4 flex-none channel-footer">
     <form class="flex w-full rounded-lg border-2 border-grey overflow-hidden" aria-labelledby="message-label">
-      <h1 id="message-label" class="sr-only">
+      <p id="message-label" class="sr-only">
         Message Input
-      </h1>
+      </p>
 
       <button class="text-3xl text-grey border-r-2 border-grey p-2" aria-label="File menu" type="button">
-        <svg class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+        <svg aria-hidden="true" class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
           <path
             d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z">
           </path>

--- a/starter-files/starter.html
+++ b/starter-files/starter.html
@@ -49,13 +49,13 @@
       </div>
     </div>
 
-    <div>
+    <button disabled>
       <svg aria-hidden="true" class="h-6 w-6 fill-current text-white opacity-25" viewBox="0 0 20 20">
         <path
           d="M14 8a4 4 0 1 0-8 0v7h8V8zM8.027 2.332A6.003 6.003 0 0 0 4 8v6l-3 2v1h18v-1l-3-2V8a6.003 6.003 0 0 0-4.027-5.668 2 2 0 1 0-3.945 0zM12 18a2 2 0 1 1-4 0h4z"
           fill-rule="evenodd"></path>
       </svg>
-    </div>
+    </button>
   </header>
 
   <nav class="mb-8 flex-1 team-sidebar__channels-list">


### PR DESCRIPTION
If merged, this PR will update the starter.html file to resolve some a11y issues: 

1.	[aria] Add a span with aria-hidden=”true” around the delete message icon
2.	[aria] add aria-hidden=”true” to the SVGs
5.	[aria] The button element does not require the role of button
6.	[aria] The form should have role=”search” (https://www.w3.org/WAI/PF/aria/roles#search)
7.	[attribute] The button in the form should have type=”submit”
10.	[color] Change the background color of the logout button, for color contrast
11.	[color] Change the color for general to black and changed the background to be lighter, in order to achieve a color contrast ratio that falls within acceptable boundaries
12.	[color] Remove the opacity class for the user name, for color contrast 
14.	[html] An H1 should not be in the footer. There should only be a single h1 per page, and it should be the page title. Changed the H1 to a p element.
