### PR TITLE
Clarify tests around guarding routes

### DIFF
--- a/notes/10-auth-service.md
+++ b/notes/10-auth-service.md
@@ -169,18 +169,18 @@ Create a new acceptance test for logging in
 ember generate acceptance-test login
 ```
 
-Open [`tests/acceptance/login-test.js`](../tests/acceptance/login-test.js) and replace the example assertions with
+Open [`tests/acceptance/login-test.js`](../tests/acceptance/login-test.js) and replace the example test with the following:
 
-```ts
+```js
+test('starting logged out, then logging in', async function(assert) {
 await visit('/login');
-
 assert.equal(currentURL(), '/login');
 
 await fillIn('select', '1');
-
 await click('form input[type="submit"]');
 
 assert.equal(currentURL(), '/teams');
+});
 ```
 
 Being sure to import what you need from `@ember/test-helpers`

--- a/notes/12-guarding-routes.md
+++ b/notes/12-guarding-routes.md
@@ -117,7 +117,7 @@ Reasons why acceptance tests are preferred (over unit tests or an integration te
 
 ### Test login
 
-In [`../tests/acceptance/login-test.js`](../tests/acceptance/login-test.js), import the `StubbedAuthService` service:
+In [`tests/acceptance/login-test.js`](../tests/acceptance/login-test.js), import the `StubbedAuthService` service:
 
 ```js
 import StubbedAuthService from '../test-helpers/auth-service';
@@ -163,7 +163,7 @@ test('already logged in', async function(assert) {
 
 ### Test logout
 
-Now let's add acceptance tests to test when users are logged out. The test file is present at [`../tests/acceptance/logout-test.js`](../tests/acceptance/logout-test.js).
+Now let's add acceptance tests to test when users are logged out. The test file is present at [`tests/acceptance/logout-test.js`](../tests/acceptance/logout-test.js).
 
 And as in the previous test, first import the `StubbedAuthService` service:
 


### PR DESCRIPTION
Previously notes/12 referred to a test name that we hadn’t yet added. This patch makes sure the expected test is present. Snuck in a couple of stylistic tweaks too.