### PR TITLE
Add Further Instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ember new -b @ember/octane-app-blueprint <app-name>
 
 Next, I installed a few packages like:
 
-- [ember-cli-tailwind](https://github.com/embermap/ember-cli-tailwind) (depricated)
+- [ember-cli-tailwind](https://github.com/embermap/ember-cli-tailwind) (deprecated)
 - [ember-on-modifier](https://github.com/buschtoens/ember-on-modifier)
 - [ember-cli-pretender](https://github.com/rwjblue/ember-cli-pretender)
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ cd shlack
 yarn install
 ```
 
+<!-- Are there options for users to use npm vs yarn if npm is their default dependency installer? -->
+
 ### Start the development server
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Make use of the many built-in Ember-CLI generators to get files that follow the 
 
 - `ember build` (development)
 - `ember build --environment production` (production)
+<!-- When should a user use which, in the case of the eng workshop? Provide more documentation -->
+
+## Troubleshooting
+
+- Be sure your watchman is up-to-date by running `brew install watchman` or follow the documentation [embercli](https://ember-cli.com/user-guide/#watchman)
+-
 
 ## Further Reading / Useful Links
 

--- a/README.md
+++ b/README.md
@@ -151,17 +151,17 @@ We _could_ create a new Ember app by running the following command (you don't ne
 ember new <app-name>
 ```
 
-This would create a project based on [the default Ember.js app blueprint](https://github.com/ember-cli/ember-cli/tree/7d9fce01d8faa4ce69cc6a8aab6f7f07b6b88425/blueprints/app). If we want to create an Ember Octane app, we can use the [official Ember Octane blueprint](https://github.com/ember-cli/ember-octane-blueprint/tree/396992a0e0582a18fe718e888a57432aaafc46fe/packages/%40ember/octane-app-blueprint) instead by running:
+This would create a project based on [the default Ember.js app blueprint](https://github.com/ember-cli/ember-cli/tree/7d9fce01d8faa4ce69cc6a8aab6f7f07b6b88425/blueprints/app).
+
+If we want to create an Ember Octane app, [Ember Octane](https://emberjs.com/editions/octane/) being the newest version of Ember.js, we can use the [official Ember Octane blueprint](https://github.com/ember-cli/ember-octane-blueprint/tree/396992a0e0582a18fe718e888a57432aaafc46fe/packages/%40ember/octane-app-blueprint) instead by running:
 
 ```sh
 ember new -b @ember/octane-app-blueprint <app-name>
 ```
 
-Beyond this, all I've done is...
+Next, I installed a few packages like:
 
-Installed a few packages like
-
-- [ember-cli-tailwind](https://github.com/embermap/ember-cli-tailwind)
+- [ember-cli-tailwind](https://github.com/embermap/ember-cli-tailwind) (depricated)
 - [ember-on-modifier](https://github.com/buschtoens/ember-on-modifier)
 - [ember-cli-pretender](https://github.com/rwjblue/ember-cli-pretender)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ ember --version
 
 and see something like
 
+<!-- The term "see something like" may confuse users from the standpoint of a user wondering if the versions should be the exact match or not and if not when does a version stray too far from the listed version below that it becomes a problem. Changing the language to something like:  "You will see the following if everything is installed correctly" may be clearer to the user. -->
+
 ```
 ember-cli: 3.10.0
 node: 11.6.0

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ ember serve
 ```
 
 - Visit your app at [http://localhost:4200](http://localhost:4200)
+  - You will see a Congratulations message if the app is correctly spun up
 - Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests)
 - Your app runs on localhost `:4200` by default. You can customize this via `--port <port-number>`
 

--- a/README.md
+++ b/README.md
@@ -20,25 +20,13 @@ There are a few things you need to ensure you have installed, in order to be rea
 
 ### Node.js
 
-You’ll need a relatively recent version (v10.0 or newer ideally) of Node.js installed. On OS X, a great way of doing this without disturbing your existing dev environment is to install NVM. [Installation instructions are here](https://github.com/creationix/nvm#installation).
+You’ll need a relatively recent version (v10.0 or newer ideally) of Node.js installed. On OS X, a great way of doing this without disturbing your existing dev environment is to install NVM.
 
 ### Install & Update Script
 
-Either download and run the nvm script manually, or run the following cURL or Wget command:
+Follow the NVM installation instruction to get set up. [Installation instructions are here](https://github.com/creationix/nvm#installation). If you are installing NVM for the first time, but sure to check your terminal for further instructions.
 
-```
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-```
-
-Then run:
-
-```
-export NVM_DIR="/Users/{username}/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-```
-
-You’ll know everything is set up properly when you can run
+You’ll know everything is set up properly when you can run:
 
 ```
 nvm --version # might look like "0.34.0"
@@ -116,8 +104,10 @@ Make use of the many built-in Ember-CLI generators to get files that follow the 
 
 ### Running Tests
 
-- `ember test` (to run all tests)
-- `ember test --server` (to re-run tests on every file change)
+You may ues _either_ of the following two commands to run the entire test suite:
+
+- `ember test`
+- `ember test --server`
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Make use of the many built-in Ember-CLI generators to get files that follow the 
 
 ### Running Tests
 
-- `ember test`
-- `ember test --server`
+- `ember test` (to run all tests)
+- `ember test --server` (to re-run tests on every file change)
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ There are a few things you need to ensure you have installed, in order to be rea
 
 You’ll need a relatively recent version (v10.0 or newer ideally) of Node.js installed. On OS X, a great way of doing this without disturbing your existing dev environment is to install NVM. [Installation instructions are here](https://github.com/creationix/nvm#installation).
 
+### Install & Update Script
+
+Either download and run the nvm script manually, or run the following cURL or Wget command:
+
+```
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+```
+
+Then run:
+
+```
+export NVM_DIR="/Users/{username}/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+```
+
 You’ll know everything is set up properly when you can run
 
 ```

--- a/notes/00-getting-started.md
+++ b/notes/00-getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+Note: If you already cloned down the repo, start fresh in a new project folder.
+
 ## ⌨️ Task: Installing Ember-CLI
 
 The goal of this task is to install ember-cli onto your machine, so you can run the `ember` command in your terminal.
@@ -23,6 +25,8 @@ ember --version
 
 and see something like
 
+<!-- The term "see something like" may confuse users from the standpoint of a user wondering if the versions should be the exact match or not and if not, when does a version stray too far from the listed version below that it becomes a problem. Changing the language to something like:  "You will see the following if everything is installed correctly" or "You should see the following output. It is okay if the versions are within a 1.0 range of the versions below" may be clearer to the user. -->
+
 ```sh
 ember-cli: 3.10.0
 node: 11.6.0
@@ -39,7 +43,11 @@ We can create a new app by running
 ember new <app-name>
 ```
 
-This will create a project based on [the default Ember.js app blueprint](https://github.com/ember-cli/ember-cli/tree/7d9fce01d8faa4ce69cc6a8aab6f7f07b6b88425/blueprints/app). If we want to create an Ember Octane app, we can use the [official Ember Octane blueprint](https://github.com/ember-cli/ember-octane-blueprint/tree/396992a0e0582a18fe718e888a57432aaafc46fe/packages/%40ember/octane-app-blueprint) instead
+The suggested app name is _Shlack_.
+
+This will create a project based on [the default Ember.js app blueprint](https://github.com/ember-cli/ember-cli/tree/7d9fce01d8faa4ce69cc6a8aab6f7f07b6b88425/blueprints/app).
+
+If we want to create an Ember Octane app, we can use the [official Ember Octane blueprint](https://github.com/ember-cli/ember-octane-blueprint/tree/396992a0e0582a18fe718e888a57432aaafc46fe/packages/%40ember/octane-app-blueprint) instead
 
 ```sh
 ember new -b @ember/octane-app-blueprint <app-name>
@@ -47,14 +55,14 @@ ember new -b @ember/octane-app-blueprint <app-name>
 
 ## ⌨️ Task: Installing dependencies
 
-The goal of this task is to install the dependencies listed in your package.json. 
-
+The goal of this task is to install the dependencies listed in your package.json.
 
 While in the project directory, run
 
 ```sh
 npm install
 ```
+
 or if using yarn
 
 ```sh
@@ -74,3 +82,5 @@ ember serve
 You should see some indication that the app is running on localhost (`:4200` by default, but customizable via `--port <port-number>`)
 
     Build successful (2158ms) – Serving on http://localhost:4200/
+
+Once you visit localhost, you will see a congratulations 🐹message if the app is correctly spun up.

--- a/notes/00-getting-started.md
+++ b/notes/00-getting-started.md
@@ -2,7 +2,7 @@
 
 Note: If you already cloned down the repo, start fresh in a new project folder.
 
-## ⌨️ Task: Installing Ember-CLI
+## Installing Ember-CLI
 
 The goal of this task is to install ember-cli onto your machine, so you can run the `ember` command in your terminal.
 
@@ -33,7 +33,7 @@ node: 11.6.0
 os: darwin x64
 ```
 
-## ⌨️ Task: Creating a new app
+## Creating a new app
 
 The goal of this task is to create a new ember app (roughly equivalent to the starting point of this course), using the official Ember Octane blueprint.
 
@@ -53,7 +53,7 @@ If we want to create an Ember Octane app, we can use the [official Ember Octane 
 ember new -b @ember/octane-app-blueprint <app-name>
 ```
 
-## ⌨️ Task: Installing dependencies
+## Installing dependencies
 
 The goal of this task is to install the dependencies listed in your package.json.
 
@@ -69,7 +69,7 @@ or if using yarn
 yarn install
 ```
 
-## ⌨️ Task: Starting the development web server
+## Starting the development web server
 
 The goal of this task is to serve your ember app using Ember CLI, and to view it in a browser.
 

--- a/notes/01-templates.md
+++ b/notes/01-templates.md
@@ -1,6 +1,6 @@
 # Templates
 
-To create the HTML portion of a web application, Ember uses declarative templates based on [Handlebars.js](https://handlebarsjs.com/) markup.
+To create the HTML portion of a web application, Ember uses declarative templates based on [Handlebars.js](https://handlebarsjs.com/) markup, a logic-less templating engine.
 
 For now, we'll just focus on this file: `app/templates/application.hbs`. Markup you put in this template will be shown anytime your app is on the screen, regardless of URL (we'll get into URLs later).
 

--- a/notes/01-templates.md
+++ b/notes/01-templates.md
@@ -1,6 +1,6 @@
 # Templates
 
-To describe the HTML portion of a web application, Ember uses declarative templates based on [Handlebars.js](https://handlebarsjs.com/) markup.
+To create the HTML portion of a web application, Ember uses declarative templates based on [Handlebars.js](https://handlebarsjs.com/) markup.
 
 For now, we'll just focus on one of these files: `app/templates/application.hbs`. Markup you put in this template will be shown anytime your app is on the screen, regardless of URL (we'll get into URLs later).
 

--- a/notes/01-templates.md
+++ b/notes/01-templates.md
@@ -2,7 +2,7 @@
 
 To create the HTML portion of a web application, Ember uses declarative templates based on [Handlebars.js](https://handlebarsjs.com/) markup.
 
-For now, we'll just focus on one of these files: `app/templates/application.hbs`. Markup you put in this template will be shown anytime your app is on the screen, regardless of URL (we'll get into URLs later).
+For now, we'll just focus on this file: `app/templates/application.hbs`. Markup you put in this template will be shown anytime your app is on the screen, regardless of URL (we'll get into URLs later).
 
 ## ⌨️ Task: Moving the initial HTML & CSS into our app
 

--- a/notes/01-templates.md
+++ b/notes/01-templates.md
@@ -4,7 +4,7 @@ To create the HTML portion of a web application, Ember uses declarative template
 
 For now, we'll just focus on this file: `app/templates/application.hbs`. Markup you put in this template will be shown anytime your app is on the screen, regardless of URL (we'll get into URLs later).
 
-## ⌨️ Task: Moving the initial HTML & CSS into our app
+## Moving the initial HTML & CSS into our app
 
 The goal of this step is to place the starting point HTML and CSS in your new app, and see what it looks like in a browser.
 

--- a/notes/01-templates.md
+++ b/notes/01-templates.md
@@ -267,3 +267,7 @@ If `ember serve` is running, you should be able to visit `http://localhost:4200`
 <img src="./img/app.png" width=800>
 
 </p>
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/5ba89d25b4a638f17a06bd1d2eb5f0e1152e2903)

--- a/notes/02-template-only-components.md
+++ b/notes/02-template-only-components.md
@@ -26,19 +26,19 @@ The goal of this step is to break various parts of [`app/templates/application.h
 1.  Create [`app/templates/components/team-selector.hbs`](../app/templates/components/team-selector.hbs)
     - Move `<nav class="team-selector">...</nav>` into it
     - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with `<TeamSelector />`
-1.  Create [`app/templates/components/team-sidebar.hbs`](../app/templates/components/team-sidebar.hbs)
+2.  Create [`app/templates/components/team-sidebar.hbs`](../app/templates/components/team-sidebar.hbs)
     - Move `<section class="team-sidebar">...</section>` into it
     - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with `<TeamSidebar />`
-1.  Create [`app/templates/components/channel-header.hbs`](../app/templates/components/channel-header.hbs)
+3.  Create [`app/templates/components/channel-header.hbs`](../app/templates/components/channel-header.hbs)
     - Move `<header class="channel-header">...</header>` into it
     - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with `<ChannelHeader />`
-1.  Create [`app/templates/components/channel-footer.hbs`](../app/templates/components/channel-footer.hbs)
+4.  Create [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs)
+    - Move one of the `<div class="message">...</div>` into it
+      - NOTE: the starting point HTML has more than one of these. Pick one to use to create the component, and for now we'll just use the one component several times
+    - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with 2 `<ChatMessage />`s
+5.  Create [`app/templates/components/channel-footer.hbs`](../app/templates/components/channel-footer.hbs)
     - Move `<footer class="channel-footer">...</footer>` into it
     - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with `<ChannelFooter />`
-1.  Create [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs)
-    - Move one of the `<div class="message">...</div>` into it
-      - NOTE: the starting point HTML has more than one of these. Pick one to use for the component, and for now we'll just repeat it several times
-    - Replace what you deleted from [`application.hbs`](../app/templates/application.hbs) with 2 `<ChatMessage />`s
 
 At the end of this, you should see no change to the rendered HTML at <http://localhost:4200>.
 

--- a/notes/02-template-only-components.md
+++ b/notes/02-template-only-components.md
@@ -4,7 +4,7 @@ Components are modular chunks of UI, and can have a `.js` file, a `.hbs` file or
 
 Usually we'd use Ember CLI to generate new components, but in this case we'll just create a new `.hbs` file for each.
 
-## ⌨️ Task: Break `application.hbs` up into several template-only components
+## Break `application.hbs` up into several template-only components
 
 The goal of this step is to break various parts of [`app/templates/application.hbs`](../app/templates/application.hbs) into their own respective `.hbs` files as template-only components. In the end, your `application.hbs` should look like
 

--- a/notes/02-template-only-components.md
+++ b/notes/02-template-only-components.md
@@ -1,6 +1,6 @@
 # Template-Only Components
 
-Components are modular chunks of UI, and can have a `.js` file, a `.hbs` file or both. We'll start with the simplest kind of component -- ones that involve no state of their own, and are defined only by a `.hbs` template file.
+Components are modular chunks of UI, and can have a `.js` file, a `.hbs` file or both. We'll start with the simplest kind of component -- ones that involve no state of their own and are logic-less, and are defined only by a `.hbs` template file. We will reserve the components with logic for the `.js` files.
 
 Usually we'd use Ember CLI to generate new components, but in this case we'll just create a new `.hbs` file for each.
 

--- a/notes/02-template-only-components.md
+++ b/notes/02-template-only-components.md
@@ -45,3 +45,7 @@ At the end of this, you should see no change to the rendered HTML at <http://loc
 ![done](./img/app.png)
 
 Congrats! You've just broken down all of that HTML into components!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/2ebe97bfe90a921a280056831595dc6cc8bf3c01)

--- a/notes/03-parameterized-components.md
+++ b/notes/03-parameterized-components.md
@@ -47,3 +47,7 @@ Go to your [`app/templates/application.hbs`](../app/templates/application.hbs) a
 Now, you should see the title and description properly rendered in the channel header
 
 ![done](./img/03-parameterized-components/done.png)
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/e9f0827798ef0d11bb91f1d059702738885f3028)

--- a/notes/03-parameterized-components.md
+++ b/notes/03-parameterized-components.md
@@ -14,7 +14,7 @@ function renderChannelHeader(args) {
 }
 ```
 
-Ember calls values that are passed into a component from the outside world in this fashion [`named args`](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md). We can recognize these named args in a template because they always begin with an `@` sign.
+Ember calls values that are passed into a component from the outside world in this fashion [`named args`](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md). We can recognize these named args in a template because they always begin with an `@` sign like this `{{ @something }}`.
 
 ## ⌨️ Task: Parameterizing `<ChannelHeader />`
 
@@ -29,7 +29,7 @@ Our component is now parameterized, and ready to receive data!
 
 ### Syntax breakdown
 
-- The `{{double-braces}}` indicate that the whatever is between them should be evaluated as a handlebars expression
+- The `{{double-braces}}` indicate that the whatever is between them should be evaluated as a [handlebars expression](https://handlebarsjs.com/guide/expressions.html)
 - The `@` indicates that `title` and `description` are named args, passed into the component from the outside world
 
 ### Passing in data

--- a/notes/03-parameterized-components.md
+++ b/notes/03-parameterized-components.md
@@ -1,6 +1,6 @@
 # Parameterized Components
 
-We can parameterize components by substituting some of the text in our hardcoded HTML with handlebars expressions (things that look like `{{ something }}`). Think of this kind of like how we can pass arguments to a function in order to get them to return new values.
+We can parameterize (to represent with parameters) components by substituting some of the text in our hardcoded HTML with handlebars expressions (things that look like `{{ something }}`). Think of this kind of like how we can pass arguments to a function in order to get them to return new values.
 
 ```jsx
 // ⚠️️ Pseudocode ⚠️

--- a/notes/03-parameterized-components.md
+++ b/notes/03-parameterized-components.md
@@ -16,7 +16,7 @@ function renderChannelHeader(args) {
 
 Ember calls values that are passed into a component from the outside world in this fashion [`named args`](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md). We can recognize these named args in a template because they always begin with an `@` sign like this `{{ @something }}`.
 
-## ⌨️ Task: Parameterizing `<ChannelHeader />`
+## Parameterizing `<ChannelHeader />`
 
 The goal of this task is to modify `<ChannelHeader />` such that we can pass in a title and description of our choice.
 

--- a/notes/04-helpers.md
+++ b/notes/04-helpers.md
@@ -8,7 +8,7 @@ Once defined, helpers can be used in _any_ of an app's templates.
 
 The goal of this task is to define a JavaScript module for date-related utilities, a `dateToString` function within it that transforms date-like values into strings, and accompanying unit tests.
 
-Your `app/utils` folder is a great place for low-level utilities like these. Let's generate a `utils` module by running
+Your `app/utils` folder is a great place for low-level utilities like these. Ember allows modules to quickly be created using the `generate` command in the cli. Let's generate a `utils` module by running
 
 ```sh
 ember generate util date
@@ -89,7 +89,7 @@ export function dateToString(date) {
 
 </details>
 
-Now, any code that needs to use this function can import it and do so
+Now, any code that needs to use this function can import it and do so. For Example:
 
 ```js
 import { dateToString } from 'shlack/utils/date';
@@ -147,7 +147,7 @@ module('Unit | Utility | date', function () {
 
 </details>
 
-Now we can go to <http://localhost:4200/tests?filter=date&nolint> and see the test runner UI, showing our test passing
+Now we can go to <http://localhost:4200/tests?filter=date&nolint> and see the test runner UI, showing our passing tests:
 
 ![unit-test](./img/04-helpers/unit-test.png)
 
@@ -155,7 +155,7 @@ Now we can go to <http://localhost:4200/tests?filter=date&nolint> and see the te
 
 Now that we have the core utility for converting a date-like thing into a consistently-formatted string, we just need create a helper to allow us to consume this in our `.hbs` files
 
-We can use Ember CLI to generate a starting point for our helper, as well as basic (passing) integration test.
+We can use Ember CLI to generate a starting point for our helper, as well as basic (passing) integration test. Let's run:
 
 ```sh
 ember generate helper format-timestamp
@@ -165,6 +165,8 @@ Ember CLI will generate the following files:
 
 - [`app/helpers/format-timestamp.js`](../app/helpers/format-timestamp.js) - the helper
 - [`tests/integration/helpers/format-timestamp-test.js`](../tests/integration/helpers/format-timestamp-test.js) - a passing integration test
+
+### Understanding Helpers
 
 The code in [`app/helpers/format-timestamp.js`](../app/helpers/format-timestamp.js) will look something like this:
 
@@ -286,3 +288,5 @@ test('No argument passed', async function (assert) {
 We don't have to worry about too much more than this, given that we've already unit tested the interesting part.
 
 Congrats! We're done with this helper!
+
+<!-- It would be great to have the completed files shown so users can compare it to their repo in case there are any mistakes in their work -->

--- a/notes/04-helpers.md
+++ b/notes/04-helpers.md
@@ -289,4 +289,6 @@ We don't have to worry about too much more than this, given that we've already u
 
 Congrats! We're done with this helper!
 
-<!-- It would be great to have the completed files shown so users can compare it to their repo in case there are any mistakes in their work -->
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/e3190f7c39ec5032c658424905cfe61d6c0e3642)

--- a/notes/04-helpers.md
+++ b/notes/04-helpers.md
@@ -97,7 +97,7 @@ import { dateToString } from 'shlack/utils/date';
 dateToString('5/3/1985'); // 'May 3, 1985 00:00.00 AM'
 ```
 
-## Task: ⌨️ Implementing a unit test
+## ⌨️ Task: Implementing a unit test
 
 Now let's fill in the regular [QUnit](http://qunitjs.com) test module that Ember CLI created for us. Replace the contents of [`tests/unit/utils/date-test.js`](../tests/unit/utils/date-test.js) with the `date-test.js` below
 
@@ -110,9 +110,9 @@ import { dateToString } from 'shlack/utils/date';
 import { module, test } from 'qunit';
 
 // A QUnit Module
-module('Unit | Utility | date', function() {
+module('Unit | Utility | date', function () {
   // A QUnit Test
-  test('string inputs', function(assert) {
+  test('string inputs', function (assert) {
     // A QUnit Assertion
     assert.equal(
       dateToString('04/05/1983'),
@@ -132,7 +132,7 @@ module('Unit | Utility | date', function() {
   });
 
   // A QUnit Test
-  test('empty and invalid inputs', function(assert) {
+  test('empty and invalid inputs', function (assert) {
     // @ts-ignore
     assert.equal(dateToString(), null);
     // @ts-ignore
@@ -242,11 +242,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | format-timestamp', function(hooks) {
+module('Integration | Helper | format-timestamp', function (hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     this.set('inputValue', '1234');
 
     await render(hbs`{{format-timestamp inputValue}}`);
@@ -277,7 +277,7 @@ You can view the current state of the tests by visiting <http://localhost:4200/t
 We can also add a negative test case below the first one (but still inside the callback passed to `module()`) to ensure the helper behaves reasonably when passed no arguments
 
 ```js
-test('No argument passed', async function(assert) {
+test('No argument passed', async function (assert) {
   await render(hbs`{{format-timestamp}}`);
   assert.equal(this.element.textContent.trim(), '(unknown)');
 });

--- a/notes/04-helpers.md
+++ b/notes/04-helpers.md
@@ -4,7 +4,7 @@ Helpers are like simple functions that can be used in templates. We'll create a 
 
 Once defined, helpers can be used in _any_ of an app's templates.
 
-## ⌨️ Task: Implementing a `dateToString` utility
+## Implementing a `dateToString` utility
 
 The goal of this task is to define a JavaScript module for date-related utilities, a `dateToString` function within it that transforms date-like values into strings, and accompanying unit tests.
 
@@ -97,7 +97,7 @@ import { dateToString } from 'shlack/utils/date';
 dateToString('5/3/1985'); // 'May 3, 1985 00:00.00 AM'
 ```
 
-## ⌨️ Task: Implementing a unit test
+## Implementing a unit test
 
 Now let's fill in the regular [QUnit](http://qunitjs.com) test module that Ember CLI created for us. Replace the contents of [`tests/unit/utils/date-test.js`](../tests/unit/utils/date-test.js) with the `date-test.js` below
 
@@ -151,7 +151,7 @@ Now we can go to <http://localhost:4200/tests?filter=date&nolint> and see the te
 
 ![unit-test](./img/04-helpers/unit-test.png)
 
-## ⌨️ Task: Implementing the `{{format-timestamp}}` helper
+## Implementing the `{{format-timestamp}}` helper
 
 Now that we have the core utility for converting a date-like thing into a consistently-formatted string, we just need create a helper to allow us to consume this in our `.hbs` files
 
@@ -222,7 +222,7 @@ Now let's put our new helper to use. Open up [`app/templates/components/chat-mes
   </time>
 ```
 
-## ⌨️ Task: Implementing an integration test
+## Implementing an integration test
 
 Next, we should also write integration tests for our helper, just to make sure the helper is hooked up to the underlying "utils" function correctly.
 

--- a/notes/05-first-routes.md
+++ b/notes/05-first-routes.md
@@ -27,7 +27,7 @@ application # application.hbs
   login     # login.hbs
   teams     # teams.hbs
     team    # teams/team.hbs
-      channel # teams/team/channel.hbs
+      channel #   teams/team/channel.hbs
 ```
 
 ![routes](./img/05-first-routes/routes.gif)
@@ -167,3 +167,7 @@ A11y tip: Notice that this logout "button" is still a link, even though it looks
 You should now be able to click on the "Logout" button and find yourself looking at the login screen with a `/login` url.
 
 Congrats! We've just set up our first routes!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/8e0808c0ec8aef96cfb638f5e7f144effebfaf72)

--- a/notes/05-first-routes.md
+++ b/notes/05-first-routes.md
@@ -32,7 +32,7 @@ application # application.hbs
 
 ![routes](./img/05-first-routes/routes.gif)
 
-## ⌨️ Task: The `/teams` route
+## The `/teams` route
 
 In this task, we'll create a new top-level template that's displayed on the screen for URLs that begin with `/teams`.
 
@@ -60,7 +60,7 @@ You should now see...
 - visiting http://localhost:4200/ shows a blank screen, with no JS errors in the console
 - visiting http://localhost:4200/teams shows the chat UI
 
-## ⌨️ Task: The `/login` route
+## The `/login` route
 
 The goal of this task is to get a login screen showing up whenever users visit URLs starting with `/login`.
 
@@ -136,7 +136,7 @@ You should now see...
 - visiting http://localhost:4200/login shows the login UI
 - visiting http://localhost:4200/teams shows the chat UI
 
-## ⌨️ Task: Creating a basic link
+## Creating a basic link
 
 In this task, we'll create our first link between routes. The default browser behavior when receiving a click on an `<a href="..."></a>` is to trigger a full page load, and this is not what we want.
 

--- a/notes/05-first-routes.md
+++ b/notes/05-first-routes.md
@@ -12,13 +12,13 @@ and the chat UI showing up when users visit http://localhost:4200/teams
 
 ## What's routing
 
-Whenever we think about URL-driven state (or content), [Routing](https://octane-guides-preview.emberjs.com/release/routing/) is likely to be involved. Our router [`app/router.js`](../app/router.js) responds to URL changes, and the appropriate routes take care of the particulars of bringing the application into the correct state for that URL (fetching the right data, rendering the right thing, etc...)
+Whenever we think about URL-driven state (or content), [Routing](https://octane-guides-preview.emberjs.com/release/routing/) is likely to be involved. Our router [`app/router.js`](../app/router.js) responds to URL changes, and the appropriate routes take care of the particulars of bringing the application into the correct state for that URL (fetching the right data, rendering the right thing, etc...).
 
 Each route is associated with a top-level template (the `.hbs` files in `app/templates` _other than_ the ones in `app/templates/components`) of a similar name. For example [`app/routes/teams.js`](../app/routes/teams.js) would have [`app/templates/teams.hbs`](../app/templates/teams.hbs) as its corresponding top-level template.
 
 The contents of our [app/templates/application.hbs](../app/templates/application.hbs) file will show up on the screen regardless of URL, but if we add a `{{outlet}}` to the template, any "child routes" will render their content into the outlet.
 
-The `application` route (we have no corresponding file for this in our project) is the highest-level route, and children can be nested such that we URL-specific content to meet our app's needs
+The `application` route (we have no corresponding file for this in our project) is the highest-level route, and children can be nested such that we URL-specific content to meet our app's needs.
 
 ### An Example Routing Hierarchy
 
@@ -26,7 +26,7 @@ The `application` route (we have no corresponding file for this in our project) 
 application # application.hbs
   login     # login.hbs
   teams     # teams.hbs
-    team    #   teams/team.hbs
+    team    # teams/team.hbs
       channel # teams/team/channel.hbs
 ```
 
@@ -166,4 +166,4 @@ A11y tip: Notice that this logout "button" is still a link, even though it looks
 
 You should now be able to click on the "Logout" button and find yourself looking at the login screen with a `/login` url.
 
-Congrats! we've just set up our first routes!
+Congrats! We've just set up our first routes!

--- a/notes/06-first-acceptance-test.md
+++ b/notes/06-first-acceptance-test.md
@@ -1,6 +1,6 @@
 # Our First Acceptance Test
 
-Good acceptance tests imitate using your app the way a user would. For browsers, this means your tests should be expressed in terms of a sequence of things like
+Good acceptance tests imitate using your app the way a user would. For browsers, this means your tests should be expressed in terms of a sequence of things like:
 
 - Visit a URL
 - Click on a button
@@ -10,7 +10,7 @@ Good acceptance tests imitate using your app the way a user would. For browsers,
 
 If you find yourself wanting to do things that a user can't do -- that's a sign that you may be diverging from the territory of acceptance tests.
 
-Ember provides fantastic support for these kinds of tests out of the box. New apps include support for [QUnit](https://qunitjs.com) by default (via the [`ember-qunit`](https://github.com/emberjs/ember-qunit)), but you can swap it out for [Mocha](https://mochajs.org/) (via [`ember-mocha`](https://github.com/emberjs/ember-mocha)) in about a minute.
+Ember provides fantastic support for these kinds of tests out of the box. New apps include support for [QUnit](https://qunitjs.com) by default (via the command [`ember-qunit`](https://github.com/emberjs/ember-qunit)), but you can swap it out for [Mocha](https://mochajs.org/) (via the command [`ember-mocha`](https://github.com/emberjs/ember-mocha)) in about a minute.
 
 <hr>
 <p>
@@ -43,10 +43,10 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-module('Acceptance | logout', function(hooks) {
+module('Acceptance | logout', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting /teams', async function(assert) {
+  test('visiting /teams', async function (assert) {
     await visit('/teams'); // Go to a URL
 
     assert.equal(currentURL(), '/teams'); // Make sure we've arrived
@@ -60,4 +60,6 @@ module('Acceptance | logout', function(hooks) {
 
 and now go to http://localhost:4200/tests. Try adding a `debugger;` to various places within this test (i.e., between `await`s). What do you notice?
 
-[Ember's test helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) can do a lot more, and are built with using `async`/`await` in mind.
+<!-- Give short explaination about Ember test helpers and how it is applicable to this project/why the dev should know about them -->
+
+[Ember's test helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) can do a lot more, and are built using `async`/`await`.

--- a/notes/06-first-acceptance-test.md
+++ b/notes/06-first-acceptance-test.md
@@ -63,3 +63,7 @@ and now go to http://localhost:4200/tests. Try adding a `debugger;` to various p
 <!-- Give short explaination about Ember test helpers and how it is applicable to this project/why the dev should know about them -->
 
 [Ember's test helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) can do a lot more, and are built using `async`/`await`.
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/672bd7d733a61ce047f5a3f49fb3d2cf6a95da29)

--- a/notes/07-first-action.md
+++ b/notes/07-first-action.md
@@ -2,6 +2,8 @@
 
 Actions are Ember's mechanism for handling user interactions through DOM events, and most often are associated with Components.
 
+<!-- Explain more: What does it mean - "are associated with Components" and why should the dev care? -->
+
 In our app, we'll need an action in order to properly handle the Login `<form>`'s "submit" event. You can think of this as kind of like defining an `onSubmit` handler
 
 ```html
@@ -32,6 +34,8 @@ loginForm.addEventListener('submit', function myFunction() {
 ```
 
 We'll see in a moment that we don't have to worry about the _imperative process_ that Ember uses to install an event listener -- we have a _declarative API_ for setting them up.
+
+<!-- Why does this matter to the dev? What is important about imperative process vs declarative API? -->
 
 ## Creating a component with a JS module
 
@@ -97,11 +101,11 @@ In this example
 
 because the `{{my-helper}}` is associated with the `class` attribute of the `<div>` -- we know it cannot be a modifier.
 
-Open your devtools and try your use of the `{{on}}` modifier out. You may notice that the selected user ID is logged to the console _briefly_ and then disappears. Why is this?
+Open your devtools and try out your use of the `{{on}}` modifier. You may notice that the selected user ID is logged to the console _briefly_ and then it disappears. Why is this?
 
 The default behavior of a form submit is to make a GET request to the current URL w/ form data serialized into queryParams. This means our single-page app is reloaded -- not what we want. We need to prevent this default behavior -- any ideas as to how we might do this?
 
-Update your event handler to use [`Event.preventDefault();`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault), so that the default form behavior is avoided
+Update your event handler to use [`Event.preventDefault();`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault), so that the default form behavior is avoided.
 
 ```js
 /**
@@ -143,7 +147,7 @@ export default class LoginFormComponent extends Component {
 
 Seems like it should work. Let's try it!
 
-Oops! we'll get an error.
+Oops! We'll get an error.
 
 ```
 login-form.js:23 Uncaught TypeError: this.handleSignIn is not a function
@@ -170,7 +174,7 @@ Can you spot the problem? What about `this`?
 
 The way the DOM API works, event handlers are called with `this` as the DOM element that received the event. This is not good in our case -- we want `this` to be the `<LoginForm />` component instance.
 
-To fix this, we'll have to `bind` the `onLoginFormSubmit` method, so that no matter who invokes it or how, `this` will always be the component instance. In Ember Octane, this can be done easily by applying the **action decorator**
+To fix this, we'll have to `bind` the `onLoginFormSubmit` method, so that no matter who invokes it or how, `this` will always be the component instance. In Ember Octane, this can be done easily by applying the **action decorator**.
 
 ```js
 /**
@@ -189,4 +193,4 @@ onLoginFormSubmit(evt) {
 
 Stop at the `debugger;` again and observe: we now have what we want, and the logging works properly again!
 
-Delete the `debugger;` inside `onLoginFormSubmit()` before we continue
+Delete the `debugger;` inside `onLoginFormSubmit()` before we continue.

--- a/notes/07-first-action.md
+++ b/notes/07-first-action.md
@@ -194,3 +194,7 @@ onLoginFormSubmit(evt) {
 Stop at the `debugger;` again and observe: we now have what we want, and the logging works properly again!
 
 Delete the `debugger;` inside `onLoginFormSubmit()` before we continue.
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/b38fd546b42681006a7ffc7df82cbf51da396c3e)

--- a/notes/08-tracked-properties.md
+++ b/notes/08-tracked-properties.md
@@ -153,3 +153,7 @@ Finally, let's go back to our JS module and make sure that if the form is disabl
 +    if (!this.isDisabled) this.handleSignIn(this.userId);
    }
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/36cef7d1b40c652b601bdd1cbd15c27c6caaca85)

--- a/notes/08-tracked-properties.md
+++ b/notes/08-tracked-properties.md
@@ -2,6 +2,8 @@
 
 Ember Octane's `tracked` property system allows us to decorate our lowest-level mutable state, and then (for the most part) treat anything downstream as if it's regular modern JavaScript.
 
+<!-- What does this mean in terms of this project? Why should a dev care? -->
+
 Let's use tracked properties to enhance our `<LoginForm />` component in the following ways:
 
 - We should have a class field `userId` that's kept in sync with the `<select>`'s value
@@ -39,7 +41,7 @@ Update the validation message in the component's template [`app/templates/compon
    </p>
 ```
 
-And hook up `isDisabled` to the `input[type="submit"]`
+And hook up `isDisabled` to the `input[type="submit"]`.
 
 ```hbs
   <input disabled={{this.isDisabled}} type="submit">
@@ -52,7 +54,7 @@ We should also show some visual indication of whether this button is disabled. R
     class="{if this.isDisabled "bg-grey" "bg-teal-dark"}} ...">
 ```
 
-And also update the `<option>` tags so their `selected` attribute is true when the `userId` property matches the selected value
+And also update the `<option>` tags so their `selected` attribute is true when the `userId` property matches the selected value.
 
 ```diff
 -   <option value="">Select a user</option>
@@ -63,12 +65,12 @@ And also update the `<option>` tags so their `selected` attribute is true when t
 +   <option value="2" selected={{eq this.userId "2"}}>Sample McData</option>
 ```
 
-We can now make two observations
+We can now make two observations:
 
 1. If we change the initializer of the `userId` class field in the component JS module, the appropriate user ends up being selected (and the validation text is also correctly initialized)
 1. If we change the selected user, the validation text is not updated properly
 
-What we're missing is a mechanism for receiving the `<select>`'s `"change"` DOM event, and updating `userId` appropriately
+What we're missing is a mechanism for receiving the `<select>`'s `"change"` DOM event, and updating `userId` appropriately.
 
 In [`app/components/login-form.js`](../app/components/login-form.js), add an action
 
@@ -83,7 +85,7 @@ onSelectChanged(evt) {
 }
 ```
 
-and in [`app/templates/components/login-form.hbs`](../app/templates/components/login-form.hbs), find the `<select>` and use the `{{on}}` modifier, so that whenever the `"change"` event is fired, the `this.onSelectChanged` action is invoked
+and in [`app/templates/components/login-form.hbs`](../app/templates/components/login-form.hbs), find the `<select>` and use the `{{on}}` modifier, so that whenever the `"change"` event is fired, the `this.onSelectChanged` action is invoked.
 
 ```hbs
 <select {{on "change" this.onSelectChanged}} >
@@ -99,6 +101,8 @@ Assertion Failed: You must use set() to set the `userId` property (of [object Ob
 ```
 
 What we're seeing is evidence that class fields work for the initial render without any special treatment, _until their value is mutated_. If we expect properties to be mutated, and those changes to cause re-renders we'll need to opt in to change tracking.
+
+<!-- Say more about this. Why do we need to opt-in to change tracking? -->
 
 First, import the `@tracked` decorator in [`app/components/login-form.js`](../app/components/login-form.js)
 
@@ -121,7 +125,7 @@ Now, try once more, and you should see that:
 - Changes to the selected user should no longer throw errors
 - The validation message should be kept in sync with the selected user
 
-Let's make our initial state a little bit more reasonable. Let's start with no user selected -- all we have to do for this is initialize `userId` to null
+Let's make our initial state a little bit more reasonable. Let's start with no user selected -- all we have to do for this is initialize `userId` to null.
 
 ```ts
 userId = null;
@@ -137,7 +141,7 @@ Let's also hide the validation text if `userId` is falsy.
   </p>
 ```
 
-Finally, let's go back to our JS module and make sure that if the form is disabled we don't call `this.handleSignIn`, and we use `userId` directly from the component class rather than querying the DOM to get the value
+Finally, let's go back to our JS module and make sure that if the form is disabled we don't call `this.handleSignIn`, and we use `userId` directly from the component class rather than querying the DOM to get the value.
 
 ```diff
    @action

--- a/notes/09-integration-tests.md
+++ b/notes/09-integration-tests.md
@@ -4,12 +4,12 @@ As we saw when writing tests for our `{{format-timestamp}}` helper, integration 
 
 Our `<LoginForm />` component has become complicated enough that we should write some meaningful tests for it.
 
-For our learning purposes, we'll just worry about two scenarios
+For our learning purposes, we'll just worry about two scenarios:
 
 - When the component is initially rendered, no user is selected, and the `input[type="submit"]` is disabled
 - Once a user is chosen, the `input[type="submit"]` is enabled, and the `<select>` should have a value of the appropriate user's id
 
-Open up the integration test for `<LoginForm />` - [`tests/integration/components/login-form-test.js`](../tests/integration/components/login-form-test.js). It should look like this
+Open up the integration test for `<LoginForm />` - [`tests/integration/components/login-form-test.js`](../tests/integration/components/login-form-test.js). It should look like this:
 
 ```ts
 import { module, test } from 'qunit';
@@ -17,10 +17,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | login-form', function(hooks) {
+module('Integration | Component | login-form', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -31,7 +31,13 @@ module('Integration | Component | login-form', function(hooks) {
         .trim()
         .replace(/\s*\n+\s*/g, '\n')
         .split('\n'),
-      ['Login', 'Select a user', 'Select a user', 'Testy Testerson', 'Sample McData']
+      [
+        'Login',
+        'Select a user',
+        'Select a user',
+        'Testy Testerson',
+        'Sample McData',
+      ]
     );
   });
 });
@@ -51,17 +57,17 @@ test module
     assertion
 ```
 
-If you go to http://localhost:4200/tests?filter=login-form&nolint, you can see this information in the test runner UI
+If you go to http://localhost:4200/tests?filter=login-form&nolint, you can see this information in the test runner UI:
 
 ![test-runner](./img/09-integration-tests/test-runner.png)
 
-Let's change the title of the existing test to something more descriptive
+Let's change the title of the existing test to something more descriptive.
 
 ```
 'initially has no user selected, and "Sign In" button disabled'
 ```
 
-We'll need to get ahold of two DOM elements to assert against
+We'll need to get ahold of two DOM elements to assert against:
 
 1. the "Sign In" button
 2. the `<select>`
@@ -71,47 +77,47 @@ let button = find('input[type="submit"]');
 let select = find('select');
 ```
 
-If you wanted to add some special autocomplete awesomeness, you could give your editor a clue (via [JSDoc comments](http://usejsdoc.org/tags-type.html)) of the types we expect `find` to return in these cases
+If you wanted to add some special autocomplete awesomeness, you could give your editor a clue (via [JSDoc comments](http://usejsdoc.org/tags-type.html)) of the types we expect `find` to return in these cases.
 
 ```js
 let button = /** @type {HTMLInputElement} */ (find('input[type="submit"]'));
 let select = /** @type {HTMLSelectElement} */ (find('select'));
 ```
 
-We will also need to import `find` from `@ember/test-helpers` by updating line 3: 
+We will also need to import `find` from `@ember/test-helpers` by updating line 3:
 
 ```js
 import { render, find } from '@ember/test-helpers';
 ```
 
-Now we can write two assertions against these
+Now we can write two assertions against these:
 
 ```js
 assert.equal(select.value, '', 'Initially, no user is selected');
 assert.equal(button.disabled, true, 'Initially the button is disabled');
 ```
 
-Go back to http://localhost:4200/tests?filter=login-form&nolint and you should see the nice assertion labels showing up
+Go back to http://localhost:4200/tests?filter=login-form&nolint and you should see the nice assertion labels showing up:
 
 ![assertion-labels](./img/09-integration-tests/assertion-labels.png)
 
-Create a new test immediately below the first one, and name it something like
+Create a new test immediately below the first one, and name it something like:
 
 ```ts
-test('after selecting a user "Sign In" button enabled', async function(assert) {
+test('after selecting a user "Sign In" button enabled', async function (assert) {
   // ...
 });
 ```
 
-define the test body as follows
+Define the test body as follows:
 
 ```ts
 // Render the component
 await render(hbs`<LoginForm />`);
 
 // Pluck off the DOM elements we care about
-let button = /** @type {HTMLInputElement} */ (find('input[type="submit"]'));
-let select = /** @type {HTMLSelectElement} */ (find('select'));
+let button = /** @type {HTMLInputElement} */ find('input[type="submit"]');
+let select = /** @type {HTMLSelectElement} */ find('select');
 
 // Select the <option> with value="1"
 await fillIn('select', '1');
@@ -137,8 +143,8 @@ assert.deepEqual(
 );
 ```
 
-Going back to http://localhost:4200/tests?filter=login-form&nolint, you should see the new test and all of our nice assertion labels in the test runner UI
+Going back to http://localhost:4200/tests?filter=login-form&nolint, you should see the new test and all of our nice assertion labels in the test runner UI.
 
 ![second-test](./img/09-integration-tests/another-test.png)
 
-Congrats! we've just written a nice component integration test!
+Congrats! We've just written a nice component integration test!

--- a/notes/09-integration-tests.md
+++ b/notes/09-integration-tests.md
@@ -148,3 +148,7 @@ Going back to http://localhost:4200/tests?filter=login-form&nolint, you should s
 ![second-test](./img/09-integration-tests/another-test.png)
 
 Congrats! We've just written a nice component integration test!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/3eb1ec93f29d6d2877871f0bc62551bdd6808ea1)

--- a/notes/10-auth-service.md
+++ b/notes/10-auth-service.md
@@ -194,3 +194,7 @@ Being sure to import what you need from `@ember/test-helpers`.
 ```ts
 import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/5a7cd8b74ac6bf429b3e15e2419d91a71a6829ec)

--- a/notes/10-auth-service.md
+++ b/notes/10-auth-service.md
@@ -2,14 +2,18 @@
 
 Services allow state and functionality (i.e., regular functions, actions) to be shared across various parts of an Ember app.
 
-In our case, there are various things that may need to "see" or "use" authentication concerns (i.e., a `currentUser`).
+<!-- Explain what services are -->
+
+In our case, there are various things that may need to "see" or "use" authentication concerns (i.e., a `currentUser`):
+
+<!-- Clearify "authentication concerns" - state it differently  -->
 
 - Creating a new chat message
 - Preventing unauthenticated users from entering the app
 - Logging in
 - Logging out
 
-We could use a component for this, but it would increase the complexity of our templates, and would involve passing extra args through the component tree.
+We could use a component for this, but it would increase the complexity of our templates, and would involve passing extra arguements through the component tree.
 
 ```hbs
 <Auth as |authApi|>
@@ -30,6 +34,8 @@ We could use a component for this, but it would increase the complexity of our t
 
 This is pretty ugly, and gets uglier as more of these cross-cutting areas are added, and more things need to access them. Thankfully, Services allow a better way of accomplishing the same thing...
 
+<!-- Clearify "cross-cutting areas" - state differently -->
+
 <hr>
 <p>
   <blockquote>
@@ -46,13 +52,13 @@ This is pretty ugly, and gets uglier as more of these cross-cutting areas are ad
 </p>
 <hr>
 
-Run the following
+Run the following:
 
 ```
 ember generate service auth
 ```
 
-This will result in two new files being created
+This will result in two new files being created.
 
 - [`app/services/auth.js`](../app/services/auth.js) - the service
 - [`tests/unit/services/auth-test.js`](../tests/unit/services/auth-test.js) - a unit test for the service
@@ -85,16 +91,16 @@ export default class AuthService extends Service {
 
 ### Delegating "logging in" to the login component
 
-Let's use this service in our `<LoginForm />` component in [`app/components/login-form.js`](../app/components/login-form.js)
+Let's use this service in our `<LoginForm />` component in [`app/components/login-form.js`](../app/components/login-form.js).
 
-Start by adding these imports
+Start by adding these imports:
 
 ```js
 import { inject as service } from '@ember/service';
 import AuthService from 'shlack/services/auth';
 ```
 
-inject the service onto the component
+Inject the service onto the component.
 
 ```ts
   /**
@@ -103,7 +109,7 @@ inject the service onto the component
   @service auth;
 ```
 
-and update the `handleSignIn` function to make use of it
+Update the `handleSignIn` function to make use of it.
 
 ```diff
    handleSignIn(value) {
@@ -115,7 +121,7 @@ and update the `handleSignIn` function to make use of it
 
 ### Rendering authentication data in the chat UI
 
-Let's show the ID of the currently logged in user in the chat sidebar component. We just have a `.hbs` file so far, so let's upgrade it to a proper component
+Let's show the ID of the currently logged in user in the chat sidebar component. We just have a `.hbs` file so far, so let's upgrade it to a proper component.
 
 **BE SURE NOT TO OVERWRITE THE TEMPLATE**
 
@@ -123,7 +129,7 @@ Let's show the ID of the currently logged in user in the chat sidebar component.
 ember generate component team-sidebar
 ```
 
-in the newly-created [`app/components/team-sidebar.js`](../app/components/team-sidebar.js), add the following service injection
+In the newly-created [`app/components/team-sidebar.js`](../app/components/team-sidebar.js), add the following service injection:
 
 ```diff
  import Component from '@glimmer/component';
@@ -138,7 +144,7 @@ in the newly-created [`app/components/team-sidebar.js`](../app/components/team-s
  }
 ```
 
-in [`app/templates/components/team-sidebar.hbs`](../app/templates/components/team-sidebar.hbs) use the currentUserId value from the service
+In [`app/templates/components/team-sidebar.hbs`](../app/templates/components/team-sidebar.hbs) use the currentUserId value from the service.
 
 ```diff
          <span class="team-sidebar__current-user-name text-white opacity-50 text-sm">
@@ -151,7 +157,7 @@ in [`app/templates/components/team-sidebar.hbs`](../app/templates/components/tea
 
 ### Tests
 
-Update the component test at [`tests/integration/components/team-sidebar-test.js`](../tests/integration/components/team-sidebar-test.js) so that it uses the following assertion
+Update the component test at [`tests/integration/components/team-sidebar-test.js`](../tests/integration/components/team-sidebar-test.js) so that it uses the following assertion:
 
 ```js
 assert.deepEqual(
@@ -163,13 +169,13 @@ assert.deepEqual(
 );
 ```
 
-Create a new acceptance test for logging in
+Create a new acceptance test for logging in.
 
 ```sh
 ember generate acceptance-test login
 ```
 
-Open [`tests/acceptance/login-test.js`](../tests/acceptance/login-test.js) and replace the example assertions with
+Open [`tests/acceptance/login-test.js`](../tests/acceptance/login-test.js) and replace the example assertions with:
 
 ```ts
 await visit('/login');
@@ -183,7 +189,7 @@ await click('form input[type="submit"]');
 assert.equal(currentURL(), '/teams');
 ```
 
-Being sure to import what you need from `@ember/test-helpers`
+Being sure to import what you need from `@ember/test-helpers`.
 
 ```ts
 import { visit, currentURL, fillIn, click } from '@ember/test-helpers';

--- a/notes/11-stubbing-services-in-tests.md
+++ b/notes/11-stubbing-services-in-tests.md
@@ -53,3 +53,7 @@ this.owner.lookup('service:auth').currentUserId = 'LOL';
 ```
 
 Make an appropriate adjustment to the assertion value, taking the userId into account and you should be good to go!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/1e1cc2df48af28de0004fe787a7faa91d2573cef)

--- a/notes/11-stubbing-services-in-tests.md
+++ b/notes/11-stubbing-services-in-tests.md
@@ -1,8 +1,10 @@
 # Stubbing Services in Tests
 
-We have a problem: our tests only pass, when we're logged in with a particular userId -- because they're actually reading/writing to cookies! This is a leak, and we need to fix it
+We have a problem: our tests only pass, when we're logged in with a particular userId -- because they're actually reading/writing to cookies! This is a leak, and we need to fix it.
 
-Create a file in your tests folder like [`tests/test-helpers/auth-service.js`](../tests/test-helpers/auth-service.js), where we'll put our "stub" service that will be used in place of the real one during tests
+Create a file in your tests folder like [`tests/test-helpers/auth-service.js`](../tests/test-helpers/auth-service.js), where we'll put our "stub" service that will be used in place of the real one during tests.
+
+<!-- Define and explain "stub" -->
 
 ```js
 import Service, { inject as service } from '@ember/service';
@@ -30,7 +32,7 @@ export default class StubbedAuthService extends Service {
 }
 ```
 
-Now we just need to install it. Go to [`tests/integration/components/team-sidebar-test.js`](../tests/integration/components/team-sidebar-test.js) and begin by importing the stub service
+Now we just need to install it. Go to [`tests/integration/components/team-sidebar-test.js`](../tests/integration/components/team-sidebar-test.js) and begin by importing the stub service.
 
 ```js
 import StubbedAuthService from 'shlack/tests/test-helpers/auth-service';
@@ -39,12 +41,12 @@ import StubbedAuthService from 'shlack/tests/test-helpers/auth-service';
 Now we just need to "register" the service before each test, ensuring our test-appropriate one is used in place of the real one. Put this code in the test module, but before any tests.
 
 ```js
-hooks.beforeEach(function() {
+hooks.beforeEach(function () {
   this.owner.register('service:auth', StubbedAuthService);
 });
 ```
 
-Finally, at the beginning of the test, set the state of the service according to our needs
+Finally, at the beginning of the test, set the state of the service according to our needs.
 
 ```js
 this.owner.lookup('service:auth').currentUserId = 'LOL';

--- a/notes/12-guarding-routes.md
+++ b/notes/12-guarding-routes.md
@@ -61,7 +61,7 @@ The jsdoc comment above, for `AuthService`, improves the developer experience wh
 ## Adding a redirect to the /login page
 
 Now let's move on to `teams` route defined at [`app/routes/teams.js`](../app/routes/teams.js).
-The `login` route should have a similar [`beforeModel`]((https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=beforeModel)) hook, but note that the validation logic is flipped in this case. We redirect to the `/login` page only the user is _logged out_.
+The `login` route should have a similar [`beforeModel`](<(https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=beforeModel)>) hook, but note that the validation logic is flipped in this case. We redirect to the `/login` page only the user is _logged out_.
 
 In the `teams` route, import the `auth` service, since its not already available(injected).
 
@@ -71,7 +71,8 @@ import { inject as service } from '@ember/service';
 import AuthService from 'shlack/services/auth';
 ```
 
-And, in the same route file([`app/routes/teams.js`](../app/routes/teams.js)), inject the imported `auth` service and add the [`beforeModel`]((https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=beforeModel)) hook to check if the user is logged in.
+And, in the same route file([`app/routes/teams.js`](../app/routes/teams.js)), inject the imported `auth` service and add the [`beforeModel`](<(https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=beforeModel)>) hook to check if the user is logged in.
+
 ```js
 
    /**
@@ -92,6 +93,9 @@ The jsdoc comment above, for `AuthService`, improves the developer experience wh
 ## Changes in Templates
 
 Now that we have the javascript implementation in place, lets add the UI for the same.
+
+<!-- What is this inreference to - "for the same"  -->
+
 In `app/templates/components/team-sidebar.hbs`, replace the `LinkTo` component with a plain old HTML `button` element with an onclick handler that will trigger the `logout` action, that you defined in `app/services/auth.js`.
 
 ```diff
@@ -126,7 +130,7 @@ import StubbedAuthService from '../test-helpers/auth-service';
 Then, inject the auth service inside the `beforeEach` hooks for test setup.
 
 ```js
-hooks.beforeEach(function() {
+hooks.beforeEach(function () {
   this.owner.register('service:auth', StubbedAuthService);
 });
 ```
@@ -134,7 +138,7 @@ hooks.beforeEach(function() {
 Modify the test with label, `starting logged out, then logging in` as follows:
 
 ```js
-test('starting logged out, then logging in', async function(assert) {
+test('starting logged out, then logging in', async function (assert) {
   const auth = this.owner.lookup('service:auth');
   auth.currentUserId = null;
 
@@ -151,7 +155,7 @@ test('starting logged out, then logging in', async function(assert) {
 Then add a test for the use case when the user is `already logged in`, as follows:
 
 ```js
-test('already logged in', async function(assert) {
+test('already logged in', async function (assert) {
   const auth = this.owner.lookup('service:auth');
   auth.currentUserId = '1';
 
@@ -177,7 +181,7 @@ And add a test with label, `visiting /teams while logged in, and then logging ou
 Modify the `beforeEach` in the same way we did for the previous test.
 
 ```js
-hooks.beforeEach(function() {
+hooks.beforeEach(function () {
   this.owner.register('service:auth', StubbedAuthService);
 });
 ```
@@ -185,7 +189,7 @@ hooks.beforeEach(function() {
 Then add the test for accessing `teams` route while being logging in, and then logging out:
 
 ```js
-test('visiting /teams while logged in, and then logging out', async function(assert) {
+test('visiting /teams while logged in, and then logging out', async function (assert) {
   const auth = this.owner.lookup('service:auth');
   auth.currentUserId = '1';
 
@@ -201,7 +205,7 @@ test('visiting /teams while logged in, and then logging out', async function(ass
 And finally, let's add a test for the use case `when visiting /teams while logged out`.
 
 ```js
-test('visiting /teams while logged out', async function(assert) {
+test('visiting /teams while logged out', async function (assert) {
   const auth = this.owner.lookup('service:auth');
   auth.currentUserId = null;
 

--- a/notes/12-guarding-routes.md
+++ b/notes/12-guarding-routes.md
@@ -214,3 +214,7 @@ test('visiting /teams while logged out', async function (assert) {
   assert.equal(currentURL(), '/login');
 });
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/f695c3d1720150a066b055b317aaef679f4d4234)

--- a/notes/13-creating-templates-and-routes.md
+++ b/notes/13-creating-templates-and-routes.md
@@ -128,9 +128,9 @@ Similar to how we created the `team` route, create a new `.js` file for `channel
 +   }
 ```
 
-In the code shown above, the `model` hook does something similar to what the `model` hook in `team` route did; that is, it will return an object from the array of objects that we defined earlier in the [`teams`](../app/routes/teams.js) route. The object that will be returned will be the one whose `id` property matches the `channelId` specified in the url for this `channel` route.
+In the code shown above, the `model` hook does something similar to what the `model` hook in the `team` route did; that is, it will return an object from the array of objects that we defined earlier in the [`teams`](../app/routes/teams.js) route. The object that will be returned will be the one whose `id` property matches the `channelId` specified in the url for this `channel` route.
 
-## Displaying Static Data in templates
+## Displaying Static Data in Templates
 
 We have now configured routes to return hard coded static data from their respective `model` hooks. Now let's start creating the templates, so that we can display the data returned from the routes.
 
@@ -146,7 +146,7 @@ In this section, we will be creating/editing the following template files:
 - [`../app/templates/components/team-sidebar.hbs`](../app/templates/components/team-sidebar.hbs)
 - [`../app/templates/teams/team/channel.hbs`](../app/templates/teams/team/channel.hbs)
 
-First, refactor the [`teams`](../app/templates/teams.hbs) template by replacing the existing content with `TeamSelector` component, that gets passed the `teams` data into it, to be displayed in its own template.
+First, refactor the [`teams`](../app/templates/teams.hbs) template by replacing the existing content with the `TeamSelector` component, which gets passed the `teams` data, to be displayed in its own template.
 
 ```diff
 -   <TeamSelector />
@@ -223,7 +223,7 @@ Here `@team` refers to the attribute that was passed in to this team-sidebar com
 +   {{@team.name}}
 ```
 
-And iterate the `channels` array that was passed in as part of the @team attribute using the [`each`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each) helper.
+Iterate the `channels` array that was passed in as part of the @team attribute using the [`each`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each) helper.
 
 ```diff
 -   <a href="/li/general" data-channel-id="general"
@@ -295,7 +295,7 @@ The `team-sidebar` component is now used with an argument, `@team`. So modify th
 +   await render(hbs`<TeamSidebar @team={{this.myTeam}}/>`);
 ```
 
-Next, add test for the new route, `team`, which is a child route of `teams` route.
+Next, add test for the new route, `team`, which is a child route of the `teams` route.
 
 For `team` (child) route, corresponding test file should be defined at [`tests/unit/routes/teams/team-test.js`](../tests/unit/routes/teams/team-test.js):
 
@@ -313,8 +313,8 @@ For `team` (child) route, corresponding test file should be defined at [`tests/u
 +   });
 ```
 
-And finally, add a test for another new route that we added, `channel`, which is a child route of `team` route.
-For `channel` (child) route, corresponding test file should be defined at [`tests/unit/routes/teams/team/channel-test.js`](../tests/unit/routes/teams/team/channel-test.js):
+And finally, add a test for another new route that we added, `channel`, which is a child route of the `team` route.
+For the `channel` (child) route, the corresponding test file should be defined at [`tests/unit/routes/teams/team/channel-test.js`](../tests/unit/routes/teams/team/channel-test.js):
 
 ```diff
 +   import { module, test } from 'qunit';

--- a/notes/13-creating-templates-and-routes.md
+++ b/notes/13-creating-templates-and-routes.md
@@ -130,7 +130,7 @@ Similar to how we created the `team` route, create a new `.js` file for `channel
 
 In the code shown above, the `model` hook does something similar to what the `model` hook in the `team` route did; that is, it will return an object from the array of objects that we defined earlier in the [`teams`](../app/routes/teams.js) route. The object that will be returned will be the one whose `id` property matches the `channelId` specified in the url for this `channel` route.
 
-## Displaying Static Data in Templates
+## Displaying Static Data in templates
 
 We have now configured routes to return hard coded static data from their respective `model` hooks. Now let's start creating the templates, so that we can display the data returned from the routes.
 

--- a/notes/13-creating-templates-and-routes.md
+++ b/notes/13-creating-templates-and-routes.md
@@ -329,3 +329,7 @@ For the `channel` (child) route, the corresponding test file should be defined a
 +     });
 +   });
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/610c5bfac850ecf0d87a0aa588fbaecaf15bd403)

--- a/notes/14-async-data-fetching.md
+++ b/notes/14-async-data-fetching.md
@@ -2,7 +2,7 @@
 
 In this exercise, we will be replacing the hard coded data that we added in previous exercises, with data fetched from server.
 
-For fetching data from server, we are going to use the [fetch](https://developers.google.com/web/updates/2015/03/introduction-to-fetch) method that is natively available in most modern browsers. In our app, we use the [ember-fetch](https://github.com/ember-cli/ember-fetch) ember addon that uses a polyfill for fetch method, in browsers that don't support the fetch method. You can find more info about browser support for fetch method [here](https://caniuse.com/#feat=fetch).
+To fetch data from the server, we are going to use the [fetch](https://developers.google.com/web/updates/2015/03/introduction-to-fetch) method that is natively available in most modern browsers. In our app, we use the [ember-fetch](https://github.com/ember-cli/ember-fetch) ember addon that uses a polyfill fetch method, in browsers that don't support the fetch method. You can find more info about browser support for fetch method [here](https://caniuse.com/#feat=fetch).
 
 We will be creating/editing the following files:
 
@@ -26,7 +26,7 @@ First, in the `login` route defined at [`../app/routes/login.js`](../app/routes/
 +   import fetch from 'fetch';
 ```
 
-Then, add a `model()` hook that returns the list of users fetched from server, by using the `fetch` method.
+Then, add a `model()` hook that returns the list of users fetched from the server, by using the `fetch` method.
 
 ```diff
 +   async model() {
@@ -38,7 +38,7 @@ Then, add a `model()` hook that returns the list of users fetched from server, b
 In the `teams` route defined at [`../app/routes/teams.js`](../app/routes/teams.js), we need to fetch the following data related to the logged in user:
 
 - User information
-- list of related teams
+- List of related teams
 
 Once again, import the `fetch` method at the top of the file, like we did for the login route:
 
@@ -114,16 +114,16 @@ Now that we are using data fetched from server, we don't need the hard coded arr
 
 ```
 
-Next file to be modified is the `team` route, defined at [`../app/routes/teams/team.js`](../app/routes/teams/team.js).
+The next file to be modified is the `team` route, defined at [`../app/routes/teams/team.js`](../app/routes/teams/team.js).
 
-Replace the import for the hard coded array, with import for `fetch`.
+Replace the import for the hard coded array, with the import for `fetch`.
 
 ```diff
 -   import { ALL_TEAMS } from '../teams';
 +   import fetch from 'fetch';
 ```
 
-Then, edit the `model()` hook to fetch data for a specific selected team from server.
+Then, edit the `model()` hook to fetch data for a specific selected team from the server.
 
 ```diff
 -   model({ teamId }) {
@@ -142,7 +142,7 @@ Next file to be modified is the `channel` route defined at [`../app/routes/teams
 +   import fetch from 'fetch';
 ```
 
-Edit the `model()` hook to fetch data from server.
+Edit the `model()` hook to fetch data from the server.
 
 ```diff
 -   model({ channelId }) {
@@ -211,7 +211,7 @@ In the [`login`](../app/templates/login.hbs) template, pass the model data into 
 +   <LoginForm @users={{this.model}}/>
 ```
 
-In the [`login-form`](`../app/templates/components/login-form.hbs`) component template, replace the hard coded values in the user selection dropdown to dynamic values fetched from server. Here `@users` contains the dynamic data that was feed into it from the `login.hbs` template.
+In the [`login-form`](`../app/templates/components/login-form.hbs`) component template, replace the hard coded values in the user selection dropdown to dynamic values fetched from the server. Here `@users` contains the dynamic data that was feed into it from the `login.hbs` template.
 
 ```diff
 -   <option selected={{eq this.userId "1"}} value="1">Testy Testerson</option>
@@ -223,7 +223,7 @@ In the [`login-form`](`../app/templates/components/login-form.hbs`) component te
 
 ## Test helper
 
-In the `auth` service defined at [`../app/services/auth.js`](../app/services/auth.js), we added some new methods. Lets update the test helper present at [`../tests/test-helpers/auth-service.js`](../tests/test-helpers/auth-service.js) accordingly. This test helper makes sure every time tests are run, there is no state leakage across tests, and application state stored on the auth service is reset, before each test is run.
+In the `auth` service defined at [`../app/services/auth.js`](../app/services/auth.js), we added some new methods. Let's update the test helper present at [`../tests/test-helpers/auth-service.js`](../tests/test-helpers/auth-service.js) accordingly. This test helper makes sure every time tests are run, there is no state leakage across tests, and application state stored on the auth service is reset, before each test is run.
 
 Add the import for `action` at the top of the file, in the imports section.
 
@@ -264,7 +264,7 @@ Note that in the above updated method definition for `loginWithUserId`, we added
 
 ## Tests
 
-Update the tests for the [`login-form`](../tests/integration/components/login-form-test.js) component to reflect the changes we made earlier in this exercise, to replace all occurrences of hard coded data with data fetched from server.
+Update the tests for the [`login-form`](../tests/integration/components/login-form-test.js) component to reflect the changes we made earlier in this exercise, to replace all occurrences of hard coded data with data fetched from the server.
 
 ```diff
 -   await render(hbs`<LoginForm />`);

--- a/notes/14-async-data-fetching.md
+++ b/notes/14-async-data-fetching.md
@@ -301,3 +301,7 @@ Update the tests for the [`login-form`](../tests/integration/components/login-fo
 ```
 
 And that's it. You are now done with this exercise!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/a48ce28356bc96e9e479399c6591dbc514628e7c)

--- a/notes/15-fowarding-routes-simulating-api-responses.md
+++ b/notes/15-fowarding-routes-simulating-api-responses.md
@@ -1,6 +1,6 @@
 # Forwarding Routes & Simulating Api Responses In Tests
 
-In this exercise, we will be mainly focussing on:
+In this exercise, we will be mainly focusing on:
 
 - Conditionally forwarding routes
 - Simulating API responses for tests
@@ -22,11 +22,11 @@ And we will be creating/editing the following files:
 
 ## Forwarding Routes
 
-For forwarding a user to a different route, other than the one that was attempted initially, we will use the [beforeModel](https://www.emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=beforeModel) hook, which is a good place to intercept requests, since it gets executed before the route fetches the data that UI needs.
+For forwarding a user to a different route, other than the one that was attempted initially, we will use the [beforeModel](https://www.emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=beforeModel) hook, which is a good place to intercept requests, since it gets executed before the route fetches the data that the UI needs.
 
 And for the actual forwarding of a route to a different route, we will use the [transitionTo](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method, that is available on all routes.
 
-Based on whether a user is logged in or not, a user trying to visit the main `index` route of the application, should be forwarded accordingly, to different routes. That is, logged in users should get forwarded to `teams` route, and users who are not logged in, should get forwarded to the `login` route.
+Based on whether a user is logged in or not, a user trying to visit the main `index` route of the application, should be forwarded accordingly, to different routes. That is, logged in users should get forwarded to the `teams` route, and users who are not logged in, should get forwarded to the `login` route.
 
 _Index routes are child routes that will be displayed first by default, when a user visits any route. You can [read more about index routes](https://guides.emberjs.com/release/routing/defining-your-routes/#toc_index-routes) in emberjs from the [emberjs guides website](https://guides.emberjs.com)_.
 
@@ -56,9 +56,9 @@ For implementing this, define the `index` route at [`../app/routes/index.js`](..
 
 Similarly when a user tries to visit the `index` route under the `teams` or the `team` route, the user should be conditionally forwarded to different routes.
 
-For `teams` route, if there is at least 1 team, the first team should be automatically displayed. Else, the index route is displayed with an appropriate message saying that that are no teams to display.
+For the `teams` route, if there is at least 1 team, the first team should be automatically displayed. Else, the index route is displayed with an appropriate message saying that that are no teams to display.
 
-Add an `index` child route for `teams` route, at [`../app/routes/teams/index.js`](../app/routes/teams/index.js):
+Add an `index` child route for the `teams` route, at [`../app/routes/teams/index.js`](../app/routes/teams/index.js):
 
 ```diff
 +   import Route from '@ember/routing/route';
@@ -105,7 +105,7 @@ Add an `index` child route for `channel` route, at [`../app/routes/teams/team/in
 
 ## Display Data In Templates
 
-Now that we have all the data that we need, let's display them, by creating the needed templates. We will be using index route templates, which are templates that will be displayed first by default, when a user visits a route.
+Now that we have all the data that we need, let's display it, by creating the needed templates. We will be using index route templates, which are templates that will be displayed first by default, when a user visits a route.
 
 For the `teams` route, if there are no teams to be displayed, an appropriate message is displayed in it's corresponding index route, which we will be creating at [`../app/templates/teams/index.hbs`](../app/templates/teams/index.hbs):
 
@@ -118,7 +118,7 @@ For the `teams` route, if there are no teams to be displayed, an appropriate mes
 -   {{outlet}}
 ```
 
-Similarly, for `channels` route, if there are no channels to be displayed, an appropriate message is displayed in it's corresponding index route, which we will be creating at [`../app/templates/teams/team/index.hbs`](../app/templates/teams/team/index.hbs):
+Similarly, for the `channels` route, if there are no channels to be displayed, an appropriate message is displayed in it's corresponding index route, which we will be creating at [`../app/templates/teams/team/index.hbs`](../app/templates/teams/team/index.hbs):
 
 ```diff
 +   <div class="mx-auto">
@@ -131,7 +131,7 @@ Similarly, for `channels` route, if there are no channels to be displayed, an ap
 
 ## Tests
 
-We modified the team and teams routes, for conditionally forwarding a user to different routes. So, let's update the tests accordingly.
+We modified the `team` and `teams` routes, for conditionally forwarding a user to different routes. So, let's update the tests accordingly.
 
 In the `login-test` test located at [`../tests/acceptance/login-test.js`](../tests/acceptance/login-test.js):
 
@@ -213,7 +213,7 @@ Now, let's add some tests for testing the route forwarding implementation, that 
 
 In the acceptance tests, we will be simulating API responses using [pretender](https://github.com/pretenderjs/pretender)(a mock server library), which we include in this application, by using the [ember-cli-pretender](https://github.com/rwjblue/ember-cli-pretender) addon.
 
-Create a new file for adding acceptance test at [`../tests/acceptance/forwarding-routes-test.js`](../tests/acceptance/forwarding-routes-test.js):
+Create a new file for adding an acceptance test at [`../tests/acceptance/forwarding-routes-test.js`](../tests/acceptance/forwarding-routes-test.js):
 
 ```diff
 +   import { module, test } from 'qunit';
@@ -310,4 +310,4 @@ In the above code that we added, apart from the actual tests, there are other fu
 - `setupServer` - function that takes care of simulating API responses used in the acceptance tests, by intercepting http requests using [pretender](https://github.com/pretenderjs/pretender), and responding with hard coded data.
 - `jsonResponse` - helper function that converts the raw response data, in this case, an array of objects, and converts it into a format that can be used by `setupServer` method.
 
-And that's it. We have now successfully implemented conditional route forwarding, and added tests for the same.
+And that's it. We have now successfully implemented conditional route forwarding, and added tests.

--- a/notes/15-fowarding-routes-simulating-api-responses.md
+++ b/notes/15-fowarding-routes-simulating-api-responses.md
@@ -311,3 +311,7 @@ In the above code that we added, apart from the actual tests, there are other fu
 - `jsonResponse` - helper function that converts the raw response data, in this case, an array of objects, and converts it into a format that can be used by `setupServer` method.
 
 And that's it. We have now successfully implemented conditional route forwarding, and added tests.
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/236b55cdbdcaf605c280d462fd9ea433b506fa52)

--- a/notes/16-container-component.md
+++ b/notes/16-container-component.md
@@ -244,3 +244,7 @@ module('Integration | Component | channel-container', function (hooks) {
   });
 });
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/cbf48e6fff59e0f76d9460c9793544b18cee2ef3)

--- a/notes/16-container-component.md
+++ b/notes/16-container-component.md
@@ -20,18 +20,18 @@ The pattern of container and presentational components was made popular by [this
 
 First, let's define two ideas that are central to this topic
 
-- A _container component_ owns state and may have some state-manipulating actions, doesn't do much in terms of rendering something to the screen. The primary purpose of one of these components is to "do things"
+- A _container component_, which owns state and may have some state-manipulating actions, doesn't do much in terms of rendering something to the screen. The primary purpose of one of these components is to "do things"
 - A _presentational component_ owns no state, and has no state-manipulating actions (although it may be passed these things as arguments). The primary purpose of one of these components is to "display things"
 
 In our app, we're going to use a container component to load channel messages, and in future exercises, create and delete messages.
 
-Let's use ember-cli to create this new component
+Let's use ember-cli to create this new component.
 
 ```sh
 ember generate component channel-container
 ```
 
-This component will hold the `messages` state (and be responsible for managing it). Let's set ourselves up for this properly in [`app/components/channel-container.js`](../app/components/channel-container.js) with the following
+This component will hold the `messages` state (and be responsible for managing it). Let's set ourselves up for this properly in [`app/components/channel-container.js`](../app/components/channel-container.js) with the following:
 
 ```js
 import Component from '@glimmer/component';
@@ -43,7 +43,7 @@ export default class ChannelContainerComponent extends Component {
 }
 ```
 
-Next, let's give ourselves a single DOM element "wrapper" around our container, and be sure to yield out the messages array so the "block" passed into our component can have access to them. In [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs), start with a template like
+Next, let's give ourselves a single DOM element "wrapper" around our container, and be sure to yield out the messages array so the "block" passed into our component can have access to them. In [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs), start with a template like:
 
 ```hbs
 <main class="flex-1 flex flex-col bg-white overflow-hidden channel">
@@ -77,7 +77,7 @@ Now let's use our component in [`app/templates/teams/team/channel.hbs`](../app/t
 + </ChannelContainer>
 ```
 
-Next, we'll need to set things up so that messages load when the component renders, and whenever the channel changes. To accomplish this, we'll use "render modifiers", which are conceptually similar to lifecycle hook, in that they let us trigger actions when a DOM element is inserted, or when a tracked property updates.
+Next, we'll need to set things up so that messages load when the component renders, and whenever the channel changes. To accomplish this, we'll use "render modifiers", which are conceptually similar to a lifecycle hook, in that they let us trigger actions when a DOM element is inserted, or when a tracked property updates.
 
 In [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs) we'll set up two modifiers: one for the initial render, and one for the `@channel` update
 
@@ -88,7 +88,7 @@ In [`app/templates/components/channel-container.hbs`](../app/templates/component
 >
 ```
 
-and define a corresponding action in [`app/components/channel-container.js`](../app/components/channel-container.js)
+and define a corresponding action in [`app/components/channel-container.js`](../app/components/channel-container.js).
 
 ```diff
 import Component from '@glimmer/component';
@@ -118,7 +118,7 @@ export default class ChannelContainerComponent extends Component {
 
 One piece of code that's worth pointing out is that last line in our new action: `this.messages = messages;`. This looks a little strange, but sheds light on the fact that _updates to tracked properties are triggered on assignment_. You can think of this like a `this.set('messages', this.get('messages'));` in the classic ember world, or `this.setState({ messages: this.messages });` in the react world.
 
-Messages should now load with the app, but they're visually identical regardless of the data passed to them. This is because we haven't parameterized them yet. In [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs) we can fix this by using the `@message` param that's now passed to this component
+Messages should now load with the app, but they're visually identical regardless of the data passed to them. This is because we haven't parameterized them yet. In [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs) we can fix this by using the `@message` param that's now passed to this component.
 
 ```diff
  <!-- Message -->
@@ -149,9 +149,9 @@ Messages should now load with the app, but they're visually identical regardless
 
 ```
 
-Now you should see messages loading as the app renders, and changing as appropriately as the user moves from channel to channel. All we need to do now is write a meaningful test.
+Now you should see messages loading as the app renders, and changing as the user moves from channel to channel. All we need to do now is write a meaningful test.
 
-There's some starter code for the mocked API responses in [`starter-files/016-pretender-server.js`](../starter-files/016-pretender-server.js). Copy the contents of this into [`tests/integration/components/channel-container-test.js`](../tests/integration/components/channel-container-test.js). Follow this with a reasonable test for asserting that messages are actually yielded out from the `<ChannelContainer />`, and that each message has an id, body and user object. Here's an example implementation
+There's some starter code for the mocked API responses in [`starter-files/016-pretender-server.js`](../starter-files/016-pretender-server.js). Copy the contents of this into [`tests/integration/components/channel-container-test.js`](../tests/integration/components/channel-container-test.js). Follow this with a reasonable test for asserting that the messages are actually yielded out from the `<ChannelContainer />`, and that each message has an id, body and user object. Here's an example implementation:
 
 ```js
 import { module, test } from 'qunit';
@@ -166,7 +166,7 @@ import Pretender, { ResponseHandler } from 'pretender';
  * @returns {ResponseHandler}
  */
 function jsonResponse(body) {
-  return function() {
+  return function () {
     return [200, {}, JSON.stringify(body)];
   };
 }
@@ -197,22 +197,22 @@ function setupServer() {
   );
 }
 
-module('Integration | Component | channel-container', function(hooks) {
+module('Integration | Component | channel-container', function (hooks) {
   setupRenderingTest(hooks);
 
   /**
    * @type {Pretender | null}
    */
   let server;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     server = new Pretender(setupServer);
   });
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     server && server.shutdown();
     server = null;
   });
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/notes/17-create-chat-message.md
+++ b/notes/17-create-chat-message.md
@@ -161,3 +161,7 @@ Go back to [`app/components/channel-footer.js`](`../app/components/channel-foote
 ```
 
 You should now be able to create chat messages!
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/8d219e83a39ba848263b49370adcba64835e01fb)

--- a/notes/17-create-chat-message.md
+++ b/notes/17-create-chat-message.md
@@ -58,7 +58,7 @@ Next, let's enhance our channel container by implementing a `createMessage` acti
   }
 ```
 
-In this component's template, let's create a new `acts` object that's yielded out, and pass our new action along as a property. Consumers can then do something like `channel.acts.createMessage` to access this function. Make the following change to [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs)
+In this component's template, let's create a new `acts` object that's yielded out, and pass our new action along as a property. Consumers can then do something like `channel.acts.createMessage` to access this function. Make the following change to [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs).
 
 ```diff
 <main class="flex-1 flex flex-col bg-white overflow-hidden channel"
@@ -74,7 +74,7 @@ In this component's template, let's create a new `acts` object that's yielded ou
 </main>
 ```
 
-Consume this new action that's yielded out of the component in [`app/templates/teams/team/channel.hbs`](../app/templates/teams/team/channel.hbs)
+Consume this new action that's yielded out of the component in [`app/templates/teams/team/channel.hbs`](../app/templates/teams/team/channel.hbs).
 
 ```diff
     {{/each}}
@@ -85,17 +85,17 @@ Consume this new action that's yielded out of the component in [`app/templates/t
 </ChannelContainer>
 ```
 
-We now have a function available to `<ChannelFooter />`, either as `@createMessage` in the component's `.hbs` file or `this.args.createMessage` within the `.js` file, which when passed a string creates a new chat message for the current user, in the current channel.
+We now have a function available to `<ChannelFooter />`, either as `@createMessage` in the component's `.hbs` file or `this.args.createMessage` within the `.js` file which, when passed a string, creates a new chat message for the current user, in the current channel.
 
-Before we use it, let's stop and think about some other reasonable behavior we might want in this component
+Before we use it, let's stop and think about some other reasonable behavior we might want in this component:
 
 - The user should be able to "click" the "send" button to create the message, or `Cmd + Enter`
   - this is an indication that we probably want the "submitting" to happen via `<form>` and the `onsubmit` event.
 - The "send" button should be disabled unless the user actually types something in the message field
   - this is an indication that we need to keep track of the `<input>`'s value at all times, and create some derived state (`isDisabled`) based on it
 
-Let's care of the "disable send, if the message is blank" functionality first. Create a new file [`app/components/channel-footer.js`](`../app/components/channel-footer.js`)
-that contains
+Let's take care of the "disable send, if the message is blank" functionality first. Create a new file [`app/components/channel-footer.js`](`../app/components/channel-footer.js`)
+that contains:
 
 ```js
 import Component from '@glimmer/component';
@@ -116,7 +116,7 @@ export default class ChannelFooterComponent extends Component {
 }
 ```
 
-We'll need to hook this up with a few changes to our existing hbs file for this component [`app/templates/components/channel-footer.hbs`](`../app/templates/components/channel-footer.hbs`)
+We'll need to hook this up with a few changes to our existing hbs file for this component [`app/templates/components/channel-footer.hbs`](`../app/templates/components/channel-footer.hbs`).
 
 ```diff
     <input id="message-input" class="channel-footer__message-input w-full px-4"
@@ -147,7 +147,7 @@ Now let's hook up that submit event. Make one more change to [`app/templates/com
     </h1>
 ```
 
-Go back to [`app/components/channel-footer.js`](`../app/components/channel-footer.js`) and add the appropriate action
+Go back to [`app/components/channel-footer.js`](`../app/components/channel-footer.js`) and add the appropriate action.
 
 ```js
   @action

--- a/notes/18-delete-chat-message.md
+++ b/notes/18-delete-chat-message.md
@@ -1,8 +1,8 @@
 # Deleting a chat message
 
-There's already a delete `<button class="message__delete-button">` in the `<ChatMessage />` component -- we just need to hook it up to something that does the appropriate deleting
+There's already a delete `<button class="message__delete-button">` in the `<ChatMessage />` component -- we just need to hook it up to something that does the appropriate deleting.
 
-Begin by defining a new action on your `<ChannelContainer />` component [`app/components/channel-container.js`](../app/components/channel-container.js) that
+Begin by defining a new action on your `<ChannelContainer />` component [`app/components/channel-container.js`](../app/components/channel-container.js) that:
 
 - makes a `DELETE` HTTP request to `/api/messages/${message.id}`, with header `Content-Type: application/json`
 - if the request can't be completed, or if it returns a non-successful status code, throw an error
@@ -34,7 +34,7 @@ Begin by defining a new action on your `<ChannelContainer />` component [`app/co
 
 ```
 
-Now we can go to this component's template, and yield this action out [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs)
+Now we can go to this component's template, and yield this action [`app/templates/components/channel-container.hbs`](../app/templates/components/channel-container.hbs).
 
 ```diff
     messages=this.messages
@@ -47,7 +47,7 @@ Now we can go to this component's template, and yield this action out [`app/temp
 
 ```
 
-and in our "channel" top-level template, pass this `deleteMessage` action to each `<ChatMessage />`. We'll want to "bake in" the message to delete using the `{{fn}}` helper, so that within the component's `.hbs` file we have a bound zero-argument function that we need only invoke at the right time. Let's open that file and hook the action up to the existing button. Open up [`app/teams/team/channel.hbs`](../app/teams/team/channel.hbs) and ensure each `<ChatMessage />` is passed the action
+and in our "channel" top-level template, pass this `deleteMessage` action to each `<ChatMessage />`. We'll want to "bake in" the message to delete using the `{{fn}}` helper, so that within the component's `.hbs` file we have a bound zero-argument function that we need only invoke at the right time. Let's open that file and hook the action up to the existing button. Open up [`app/teams/team/channel.hbs`](../app/teams/team/channel.hbs) and ensure each `<ChatMessage />` is passed the action.
 
 ```diff
     {{#each ch.messages as |message|}}
@@ -56,7 +56,7 @@ and in our "channel" top-level template, pass this `deleteMessage` action to eac
     {{/each}}
 ```
 
-Finally, let's go into the component, and hook the action up to the existing button. In [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs), make the following change
+Finally, let's go into the component, and hook the action up to the existing button. In [`app/templates/components/chat-message.hbs`](../app/templates/components/chat-message.hbs), make the following change:
 
 ```diff
 - <button
@@ -64,4 +64,4 @@ Finally, let's go into the component, and hook the action up to the existing but
   class="message__delete-button border-transparent hover:border-red-light show-on-hover hover:bg-red-lightest border-1 rounded mb-1 pl-3 pr-2 py-1"
 ```
 
-You should now be able to hover over each message to see a "delete" button, and clicking on one of these should result in the `DELETE` api call being made, and the message being removed from the screen (and your `db.json` database)
+You should now be able to hover over each message to see a "delete" button, and clicking on one of these should result in the `DELETE` api call being made, and the message being removed from the screen (and your `db.json` database).

--- a/notes/18-delete-chat-message.md
+++ b/notes/18-delete-chat-message.md
@@ -65,3 +65,7 @@ Finally, let's go into the component, and hook the action up to the existing but
 ```
 
 You should now be able to hover over each message to see a "delete" button, and clicking on one of these should result in the `DELETE` api call being made, and the message being removed from the screen (and your `db.json` database).
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/20c4578f07ae35ac64b867dc0ad0ec00d53bf8a7)

--- a/notes/19-notification-center.md
+++ b/notes/19-notification-center.md
@@ -221,3 +221,7 @@ Now all we have left to do is use the service to create notifications in respons
 ```
 
 You should now see notifications upon creation and deletion of messages, both for successful completion of these operations and when the app encounters an error.
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/7670d6d56cc6d80d306a1761c3d50971598dd1f1)

--- a/notes/19-notification-center.md
+++ b/notes/19-notification-center.md
@@ -2,9 +2,12 @@
 
 While components are generally reusable, sometimes it's more convenient to use _singleton state_ to drive a component, particularly in cases where many parts of a codebase need to be able to get involved with its behavior. A great example of this kind of pattern is a notification center.
 
+<!-- Explain what singleton state is -->
+<!-- Explain more about why a notification center is a good example of this involved behavior -->
+
 ## The Notification Component
 
-Let's begin with a `<Notification />` component. Create the file [`app/templates/components/notification.hbs`](../app/templates/components/notification.hbs) as follows
+Let's begin with a `<Notification />` component. Create the file [`app/templates/components/notification.hbs`](../app/templates/components/notification.hbs) as follows:
 
 ```hbs
 <div class="notification flex flex-row items-center bg-{{@notification.color}} text-white text-sm font-bold px-4 py-3 notification-transition {{if @notification.entering "entering" ""}} {{if @notification.leaving "leaving" ""}}"
@@ -27,7 +30,7 @@ This component uses a pattern where we can have a default DOM structure for noti
 <Notification @notification=... />
 ```
 
-but can also customize it by using the "block form"
+but can also customize it by using the "block form".
 
 ```hbs
 <Notification @notification=... >
@@ -45,7 +48,7 @@ Next, let's build a service to hold the collection of notifications
 ember generate service notifications
 ```
 
-and implement [`app/services/notifications.js`](../app/services/notifications.js) as follows
+and implement [`app/services/notifications.js`](../app/services/notifications.js) as follows:
 
 ```js
 import Service from '@ember/service';
@@ -74,7 +77,7 @@ export default class NotificationsService extends Service {
     // REMOVE after elapsed time is complete
     setTimeout(() => {
       // remove notification by ID
-      const idx = this.messages.map(n => `${n.id}`).indexOf(`${id}`);
+      const idx = this.messages.map((n) => `${n.id}`).indexOf(`${id}`);
       this.messages.splice(idx, 1);
 
       // tracked property update via assignment
@@ -84,11 +87,11 @@ export default class NotificationsService extends Service {
 }
 ```
 
-now, anywhere we need to be able to provide notifications, we need only inject this service and call `notifications.notify('Message');`.
+Now, anywhere we need to be able to provide notifications, we need only inject this service and call `notifications.notify('Message');`:
 
 ## The List of Notifications
 
-We'll need a component for the list of notifications. Let's use ember-cli to generate one
+We'll need a component for the list of notifications. Let's use the ember-cli to generate one
 
 ```sh
 ember generate component notification-list
@@ -119,7 +122,7 @@ and its HBS file [`app/templates/components/notification-list.hbs`](../app/templ
 </div>
 ```
 
-Let's use this component at the top of the channel, above all of the messages. Open [`app/templates/teams/team/channel.hbs`](../app/templates/teams/team/channel.hbs) and make the following change
+Let's use this component at the top of the channel, above all of the messages. Open [`app/templates/teams/team/channel.hbs`](../app/templates/teams/team/channel.hbs) and make the following change:
 
 ```diff
   <ChannelHeader @title={{this.model.name}} @description={{this.model.description}} />

--- a/notes/20-server-rendering.md
+++ b/notes/20-server-rendering.md
@@ -6,7 +6,7 @@ The idea is that you should _not_ be writing two apps (despite needing to run on
 
 ![js environments](./img/20-server-rendering/js-envs.png)
 
-First, let's install fastboot to enable server-rendering
+First, let's install fastboot to enable server-rendering.
 
 ```
 ember install ember-cli-fastboot
@@ -23,7 +23,7 @@ Open your [`config/environment.js`](../config/environment.js), and add a `fastbo
 
 We'll have to refactor our `auth` service so that it doesn't use any browser-specific APIs.
 
-To do this we can install `ember-cookies`, a unified abstraction that can provide us with a way of dealing with cookies both in node and in a browser environment
+To do this we can install `ember-cookies`, a unified abstraction that can provide us with a way of dealing with cookies both in node and in a browser environment.
 
 ```
 ember install ember-cookies
@@ -37,7 +37,7 @@ Next, we'll have to make some adjustments to the auth service. Begin by importin
 import CookiesService from 'ember-cookies/services/cookies';
 ```
 
-and inject the `cookies` service onto the `auth` service
+and inject the `cookies` service onto the `auth` service.
 
 ```ts
  /**
@@ -46,7 +46,7 @@ and inject the `cookies` service onto the `auth` service
  @service cookies;
 ```
 
-Update the `loginWithUserId` function so it writes to a cookie instead of `localStorage`
+Update the `loginWithUserId` function so it writes to a cookie instead of `localStorage`.
 
 ```diff
    async loginWithUserId(userId) {
@@ -65,7 +65,7 @@ Update the `currentUserId` getter so it reads from a cookie
    }
 ```
 
-and update `logout so it clears the value from the cookie instead of`localStorage`
+and update `logout so it clears the value from the cookie instead of`localStorage`.
 
 ```diff
    logout() {

--- a/notes/20-server-rendering.md
+++ b/notes/20-server-rendering.md
@@ -75,3 +75,7 @@ and update `logout so it clears the value from the cookie instead of`localStorag
    }
  }
 ```
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/cc08ad8054d706c3d4efd4ae286f186ae2430533)

--- a/notes/21-pwa.md
+++ b/notes/21-pwa.md
@@ -60,3 +60,7 @@ Now, to test out our ability to go offline:
 The app will load! You can even turn off your wifi and the app will still work!
 
 Note that as soon as you try to see anything you haven't previously seen (i.e., a channel you haven't clicked on), you'll get an error. You're caching API payloads _as they fly by_. Deliberately caching particular URLs is a very easy change to make, but beyond the scope of this course.
+
+## Completed File
+
+[view here](https://github.com/mike-north/ember-octane-workshop/commit/1e9096c8021ca184407128f9b2e95b8fa8400865)

--- a/notes/21-pwa.md
+++ b/notes/21-pwa.md
@@ -1,14 +1,14 @@
 # Progressive Web App
 
 PWA technologies allow us to push web apps even closer to a native-like experience. The most powerful (and challenging to implement) part
-of this group of APIs is a _Service Worker_
+of this group of APIs is a _Service Worker_.
 
 Service workers are a topic in and of themselves, and if you want to learn more about them
 
-- see my PWA course
-- kyle simpson has a workshop too (https://frontendmasters.com/workshops/service-worker-pwa/)
+- See my PWA course
+- Kyle Simpson has a workshop too (https://frontendmasters.com/workshops/service-worker-pwa/)
 
-Thankfully, Ember's opinionated ecosystem allows us to share a common package for this
+Thankfully, Ember's opinionated ecosystem allows us to share a common package for this.
 
 ```sh
 ember install \
@@ -18,7 +18,7 @@ ember install \
   ember-service-worker-index # special handling of index.html
 ```
 
-There's _almost_ no configuration required. The one thing we have to do is inform the fallback cache of the URLs we want it to "save" data for as they pass through. This way if we lose connectivity, we'll fall back to the cached payloads.
+There's _almost_ no configuration required. The one thing we have to do is inform the fallback cache of the URLs that we want it to "save" data as it passes through. This way, if we lose connectivity, we'll fall back to the cached payloads.
 
 Open [`ember-cli-build.js`](../ember-cli-build.js) and make this change.
 
@@ -30,7 +30,7 @@ Open [`ember-cli-build.js`](../ember-cli-build.js) and make this change.
    });
 ```
 
-Now if you go to the service worker section of your devtools, you should see something like this.
+Now if you go to the service worker section of your devtools, you should see something like this:
 
 ![service-worker devtools](img/21-pwa/sw-devtools.png)
 
@@ -51,7 +51,7 @@ Now if you go to the service worker section of your devtools, you should see som
 </p>
 <hr>
 
-Now, to test out our ability to go offline,
+Now, to test out our ability to go offline:
 
 - Uncheck all boxes
 - Reload


### PR DESCRIPTION
Hi Mike,

We spoke several months ago about this project and how Koushik and the team are excited to use it for the Eng Bootcamp. I have been in conversation with a few other contributors on this repo as far as making sure it is totally accessible and that there is an exercise for accessibility testing built in. We will be reaching out about that soon. While we are still working on some ember updates, I wanted to begin making PRs on the ReadMe. The goal is to ensure the instructions make the project accessible to engineers of all incoming skill levels. I look forward to collaborating with you! 

This PR adds the first instructional change by including the commands from the external documentation for nvm directly in the ReadMe so bootcampers do not have to make an extra click out of the project and discern what part of the documentation they are supposed to follow and integrate.  

Looking forward to your feedback!